### PR TITLE
fix: resolve CI test-build import NameError for SyncStreamResponse

### DIFF
--- a/justllms/core/base.py
+++ b/justllms/core/base.py
@@ -150,7 +150,7 @@ class BaseProvider(ABC):
         model: str,
         timeout: Optional[float] = None,
         **kwargs: Any,
-    ) -> SyncStreamResponse:
+    ) -> "SyncStreamResponse":
         """Stream completion - same parameters as complete().
 
         Default implementation raises NotImplementedError.

--- a/justllms/core/completion.py
+++ b/justllms/core/completion.py
@@ -133,7 +133,7 @@ class Completion:
         user: Optional[str] = None,
         timeout: Optional[float] = None,
         **kwargs: Any,
-    ) -> SyncStreamResponse: ...
+    ) -> "SyncStreamResponse": ...
 
     def create(
         self,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Test Build** CI job installs the built wheel and runs `python -c "import justllms"`. That step failed on all Python versions because `SyncStreamResponse` was only imported under `TYPE_CHECKING`, while `BaseProvider.stream()` and a `Completion.create()` overload still used it as a **runtime** return annotation. Python evaluates those annotations when defining the class, which raised `NameError: name 'SyncStreamResponse' is not defined`.

## Changes

- `justllms/core/base.py`: use a string forward reference for the `stream()` return type (`"SyncStreamResponse"`).
- `justllms/core/completion.py`: same for the `@overload` branch that returns a stream.

## Verification

Locally: `ruff check justllms/`, `black --check justllms/`, `mypy justllms/ --ignore-missing-imports`, then `python -m build`, install `dist/*.whl` into a clean `PYTHONPATH`, and `import justllms` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff65e7a8-8257-41f9-af93-43fe7e56159e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff65e7a8-8257-41f9-af93-43fe7e56159e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

