### PR TITLE
fix: handle empty YAML and JSON config files

### DIFF
--- a/justllms/config/config.py
+++ b/justllms/config/config.py
@@ -62,6 +62,13 @@ class Config(BaseModel):
             else:
                 raise ValueError(f"Unsupported configuration file format: {path.suffix}")
 
+        if data is None:
+            data = {}
+        elif not isinstance(data, dict):
+            raise ValueError(
+                f"Configuration file must contain a mapping at the top level, got {type(data).__name__}"
+            )
+
         return cls(**data)
 
     @classmethod


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Loading an empty `justllms.yaml` / `justllms.yml` or a JSON file containing only `null` caused `Config.from_file()` to crash with `TypeError: argument after ** must be a mapping, not NoneType`, because `yaml.safe_load()` and `json.load()` return `None` for those inputs.

This change treats `null`/empty documents as an empty configuration mapping (same as `{}`) and raises a clear `ValueError` when the top-level document is not a mapping (for example, a YAML list).

## Changes

- `Config.from_file()` now normalizes `None` to `{}` before constructing `Config`
- Non-mapping top-level values raise `ValueError` with a descriptive message

## Testing

Ran the full CI workflow locally:

- `ruff check justllms/`
- `black --check justllms/`
- `mypy justllms/ --ignore-missing-imports`
- `python -m build` + wheel import smoke test

Verified manually:

- Empty `.yaml` → returns `Config()` with default empty providers
- `.json` containing `null` → same behavior
- YAML list at top level → `ValueError`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e807d0a-b7cd-49d5-9c33-0f41e4c19843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e807d0a-b7cd-49d5-9c33-0f41e4c19843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

