### PR TITLE
feat: usage tracking and budget limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,61 @@ Streaming and tool-calling requests keep their current behavior, though
 HTTP-level retries (3 attempts with exponential backoff on 429/408/5xx and
 network errors) still apply to every request.
 
+### Cost Tracking & Budgets
+Every completion (including streaming and tool calls) is tracked automatically — no setup required:
+
+```python
+client.completion.create(messages=[{"role": "user", "content": "Hello"}])
+
+print(client.get_usage_summary())
+# {
+#     "total_cost": 0.000125,
+#     "total_tokens": 42,
+#     "total_prompt_tokens": 12,
+#     "total_completion_tokens": 30,
+#     "request_count": 1,
+#     "by_provider": {"openai": {"requests": 1, "prompt_tokens": 12, ...}},
+#     "by_model": {"openai/gpt-4o-mini": {"requests": 1, "cost": 0.000125, ...}}
+# }
+
+client.reset_usage()  # start a fresh accounting window
+```
+
+Optionally enforce budget limits via config (dict or YAML):
+
+```python
+client = JustLLM({
+    "providers": {"openai": {"api_key": "your-key"}},
+    "budget": {
+        "max_cost": 5.00,        # USD, cumulative
+        "max_tokens": 1000000,   # cumulative total tokens
+        "max_requests": 1000,    # cumulative request count
+        "on_exceeded": "raise"   # or "warn" to log and continue
+    }
+})
+```
+
+```yaml
+# justllms.yaml
+budget:
+  max_cost: 5.00
+  max_requests: 1000
+  on_exceeded: raise
+```
+
+When a limit is reached, subsequent requests raise `BudgetExceededError`:
+
+```python
+from justllms import BudgetExceededError
+
+try:
+    response = client.completion.create(messages=[{"role": "user", "content": "Hello"}])
+except BudgetExceededError as e:
+    print(f"Budget hit: {e.limit_type} at {e.current} (limit {e.limit})")
+```
+
+Note: budget checks are *pre-flight* — each request is checked against usage accumulated so far, so the request that crosses a limit completes normally and the next one is blocked. Limits are cumulative for the client's lifetime (or since `reset_usage()`).
+
 ## Side-by-Side Model Comparison
 
 Compare multiple LLM providers and models simultaneously with our interactive SXS (Side-by-Side) comparison tool. Perfect for evaluating model performance, testing prompts, and making informed decisions about which models to use.

--- a/justllms/__init__.py
+++ b/justllms/__init__.py
@@ -2,7 +2,8 @@ from justllms.__version__ import __version__
 from justllms.core.client import Client
 from justllms.core.completion import Completion, CompletionResponse
 from justllms.core.models import Message, Role
-from justllms.exceptions import JustLLMsError, ProviderError
+from justllms.exceptions import BudgetExceededError, JustLLMsError, ProviderError
+from justllms.monitoring import BudgetConfig, BudgetManager, UsageRecord, UsageTracker
 from justllms.tools import GoogleCodeExecution, GoogleSearch, Tool, ToolRegistry, tool
 
 JustLLM = Client
@@ -17,6 +18,11 @@ __all__ = [
     "Role",
     "JustLLMsError",
     "ProviderError",
+    "BudgetExceededError",
+    "BudgetConfig",
+    "BudgetManager",
+    "UsageRecord",
+    "UsageTracker",
     "tool",
     "Tool",
     "ToolRegistry",

--- a/justllms/config/config.py
+++ b/justllms/config/config.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional, Union
 import yaml  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field
 
+from justllms.monitoring.budget import BudgetConfig
+
 
 class ConfigProviderSettings(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -61,6 +63,7 @@ class Config(BaseModel):
 
     providers: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     routing: RoutingConfig = Field(default_factory=RoutingConfig)
+    budget: Optional[BudgetConfig] = None
 
     @classmethod
     def from_file(cls, path: Union[str, Path]) -> "Config":

--- a/justllms/core/client.py
+++ b/justllms/core/client.py
@@ -1,11 +1,12 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from justllms.config import Config
 from justllms.core.base import BaseProvider, BaseResponse
 from justllms.core.completion import Completion, CompletionResponse
 from justllms.core.models import Message, ProviderConfig
 from justllms.exceptions import ConfigurationError, ProviderError
+from justllms.monitoring import BudgetManager, UsageTracker
 from justllms.reliability import FallbackExecutor
 from justllms.routing import Router
 
@@ -32,6 +33,13 @@ class Client:
         self.router = router or Router(self.config.routing)
         self.default_model = default_model
         self.default_provider = default_provider
+
+        # Usage tracking is always on (negligible overhead); budget
+        # enforcement only when configured.
+        self.usage = UsageTracker()
+        self.budget: Optional[BudgetManager] = (
+            BudgetManager(self.config.budget, self.usage) if self.config.budget else None
+        )
 
         from justllms.tools.registry import ToolRegistry
 
@@ -254,6 +262,7 @@ class Client:
             provider_instance = self.providers[name]
             response = provider_instance.complete(messages=messages, model=model_name, **kwargs)
             self._estimate_and_set_cost(response, provider_instance, model_name)
+            self.usage.record(name, model_name, response.usage)
             return self._wrap_completion_response(response, name)
 
         if not use_fallback:
@@ -267,6 +276,38 @@ class Client:
             completion.fallback_attempts = [attempt.to_dict() for attempt in attempts]
 
         return completion
+
+    def _make_stream_usage_callback(
+        self, provider_name: str, model: str
+    ) -> "Callable[[CompletionResponse], None]":
+        """Build an on_complete callback that records streaming usage.
+
+        Args:
+            provider_name: Provider used for the streaming request.
+            model: Model used for the streaming request.
+
+        Returns:
+            Callback for SyncStreamResponse.on_complete that records the
+            final response's usage in the client's UsageTracker.
+        """
+
+        def _on_complete(final_response: "CompletionResponse") -> None:
+            self.usage.record(provider_name, model, final_response.usage, streamed=True)
+
+        return _on_complete
+
+    def get_usage_summary(self) -> Dict[str, Any]:
+        """Get aggregated usage and cost totals for this client.
+
+        Returns:
+            Dict with total_cost, total_tokens, request_count and
+            per-provider/per-model breakdowns.
+        """
+        return self.usage.get_summary()
+
+    def reset_usage(self) -> None:
+        """Reset accumulated usage (also resets budget accounting)."""
+        self.usage.reset()
 
     def _create_completion(
         self,
@@ -305,6 +346,11 @@ class Client:
                           completion request fails, or if streaming is requested
                           but the provider doesn't support it.
         """
+        # Pre-flight budget check: blocks this request if a limit was already
+        # reached by previous requests (the crossing request itself completes).
+        if self.budget is not None:
+            self.budget.check()
+
         # Per-request failover override; popped so it never reaches provider payloads.
         fallback_override: Optional[bool] = kwargs.pop("fallback", None)
 
@@ -346,8 +392,10 @@ class Client:
             max_iterations = kwargs.pop("max_iterations", self.config.routing.max_tool_iterations)
             timeout = kwargs.pop("timeout", None)
 
-            # Call tool-enabled completion
-            return self.completion._create_with_tools(
+            # Call tool-enabled completion. Usage tracking counts the final
+            # response only; intermediate tool-loop LLM calls inside
+            # Completion._create_with_tools are not recorded individually.
+            tool_response = self.completion._create_with_tools(
                 messages=messages,
                 tools=tools,
                 provider=provider_name,
@@ -358,6 +406,8 @@ class Client:
                 timeout=timeout,
                 **kwargs,
             )
+            self.usage.record(provider_name, selected_model, tool_response.usage)
+            return tool_response
 
         if provider:
             if provider not in self.providers:
@@ -392,7 +442,13 @@ class Client:
                     )
 
                 # Stream with specified provider
-                return provider_instance.stream(messages=messages, model=selected_model, **kwargs)
+                stream_response = provider_instance.stream(
+                    messages=messages, model=selected_model, **kwargs
+                )
+                stream_response.on_complete = self._make_stream_usage_callback(
+                    provider, selected_model
+                )
+                return stream_response
             else:
                 # Non-streaming with specified provider; explicit provider is the
                 # primary and the configured fallback chain still applies after it.
@@ -411,7 +467,13 @@ class Client:
 
             # Stream with routed provider
             provider_instance = self.providers[provider_name]
-            return provider_instance.stream(messages=messages, model=selected_model, **kwargs)
+            stream_response = provider_instance.stream(
+                messages=messages, model=selected_model, **kwargs
+            )
+            stream_response.on_complete = self._make_stream_usage_callback(
+                provider_name, selected_model
+            )
+            return stream_response
         else:
             # Non-streaming route
             provider_name, selected_model = self.router.route(

--- a/justllms/core/streaming.py
+++ b/justllms/core/streaming.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, Iterator, List, Optional
@@ -9,6 +10,8 @@ from justllms.core.models import Choice, Message, Role, Usage
 if TYPE_CHECKING:
     from justllms.core.base import BaseProvider
     from justllms.core.completion import CompletionResponse
+
+logger = logging.getLogger(__name__)
 
 
 def parse_sse_stream(
@@ -173,6 +176,7 @@ class SyncStreamResponse:
         model: str,
         messages: List[Message],
         raw_stream: Iterator[StreamChunk],
+        on_complete: Optional[Callable[["CompletionResponse"], None]] = None,
     ):
         """Initialize sync stream response.
 
@@ -181,10 +185,15 @@ class SyncStreamResponse:
             model: Model name.
             messages: Original messages.
             raw_stream: Iterator of StreamChunks.
+            on_complete: Optional callback invoked exactly once with the final
+                CompletionResponse when it is first built (e.g. for usage
+                tracking). Callback errors are logged, never raised.
         """
         self.accumulator = StreamResponse(provider, model, messages)
         self.raw_stream = raw_stream
         self._iterator_started = False
+        self.on_complete = on_complete
+        self._on_complete_fired = False
 
     def __iter__(self) -> Iterator[StreamChunk]:
         """Iterate over stream chunks.
@@ -236,7 +245,14 @@ class SyncStreamResponse:
         """
         if not self.accumulator.completed:
             self.drain()
-        return self.accumulator.to_completion_response()
+        response = self.accumulator.to_completion_response()
+        if self.on_complete is not None and not self._on_complete_fired:
+            self._on_complete_fired = True
+            try:
+                self.on_complete(response)
+            except Exception as exc:  # noqa: BLE001 - callback must never break streaming
+                logger.warning("Stream on_complete callback failed: %s", exc)
+        return response
 
 
 class AsyncStreamResponse:

--- a/justllms/exceptions/__init__.py
+++ b/justllms/exceptions/__init__.py
@@ -1,5 +1,6 @@
 from justllms.exceptions.exceptions import (
     AuthenticationError,
+    BudgetExceededError,
     ConfigurationError,
     JustLLMsError,
     ProviderError,
@@ -15,5 +16,6 @@ __all__ = [
     "RateLimitError",
     "TimeoutError",
     "AuthenticationError",
+    "BudgetExceededError",
     "ConfigurationError",
 ]

--- a/justllms/exceptions/exceptions.py
+++ b/justllms/exceptions/exceptions.py
@@ -107,6 +107,34 @@ class AuthenticationError(ProviderError):
         self.required_auth = required_auth
 
 
+class BudgetExceededError(JustLLMsError):
+    """Raised when a configured budget limit has been reached.
+
+    Budget checks are pre-flight: the request that crosses a limit completes,
+    and this error is raised for subsequent requests.
+
+    Args:
+        message: Human-readable error description.
+        limit_type: Which limit was breached: "cost", "tokens", or "requests".
+        limit: The configured limit value.
+        current: The accumulated usage value that reached the limit.
+        **kwargs: Additional arguments passed to parent JustLLMsError.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        limit_type: Optional[str] = None,
+        limit: Optional[float] = None,
+        current: Optional[float] = None,
+        **kwargs: Any,
+    ):
+        super().__init__(message, **kwargs)
+        self.limit_type = limit_type
+        self.limit = limit
+        self.current = current
+
+
 class ConfigurationError(JustLLMsError):
     """Configuration error."""
 

--- a/justllms/monitoring/__init__.py
+++ b/justllms/monitoring/__init__.py
@@ -1,0 +1,9 @@
+from justllms.monitoring.budget import BudgetConfig, BudgetManager
+from justllms.monitoring.usage import UsageRecord, UsageTracker
+
+__all__ = [
+    "BudgetConfig",
+    "BudgetManager",
+    "UsageRecord",
+    "UsageTracker",
+]

--- a/justllms/monitoring/budget.py
+++ b/justllms/monitoring/budget.py
@@ -1,0 +1,109 @@
+"""Budget limits enforced against accumulated usage.
+
+Budget checks are *pre-flight*: :meth:`BudgetManager.check` is called before
+each request and compares the limits against usage accumulated so far. This
+means the request that crosses a limit completes normally, and the *next*
+request is blocked (or warned about). This keeps enforcement cheap and avoids
+having to predict a request's cost up front.
+"""
+
+import logging
+from typing import Optional, Set
+
+from pydantic import BaseModel, ConfigDict
+
+from justllms.exceptions import BudgetExceededError
+from justllms.monitoring.usage import UsageTracker
+
+logger = logging.getLogger(__name__)
+
+
+class BudgetConfig(BaseModel):
+    """Configuration for budget limits.
+
+    All limits are cumulative for the lifetime of the client's UsageTracker
+    (i.e. since client creation or the last ``reset_usage()`` call).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    enabled: bool = True
+    max_cost: Optional[float] = None
+    """Maximum cumulative estimated cost in USD."""
+
+    max_tokens: Optional[int] = None
+    """Maximum cumulative total tokens."""
+
+    max_requests: Optional[int] = None
+    """Maximum cumulative request count."""
+
+    on_exceeded: str = "raise"
+    """What to do when a limit is reached: "raise" (default) or "warn"."""
+
+
+class BudgetManager:
+    """Enforces budget limits against a UsageTracker.
+
+    Semantics: ``check()`` is a pre-flight gate. It raises (or warns) when a
+    limit has *already* been reached by previous requests, so the request that
+    crosses a limit is allowed to complete and subsequent requests are blocked.
+    """
+
+    def __init__(self, config: BudgetConfig, tracker: UsageTracker):
+        """Initialize the budget manager.
+
+        Args:
+            config: Budget limits and behavior configuration.
+            tracker: UsageTracker holding the accumulated usage to check against.
+        """
+        self.config = config
+        self.tracker = tracker
+        self._warned_types: Set[str] = set()
+
+    def check(self) -> None:
+        """Check accumulated usage against configured limits.
+
+        Call before dispatching a request. No-op if budgets are disabled or
+        no limits are configured.
+
+        Raises:
+            BudgetExceededError: If a limit is reached and on_exceeded="raise".
+        """
+        if not self.config.enabled:
+            return
+
+        if self.config.max_cost is not None:
+            current_cost = self.tracker.total_cost
+            if current_cost >= self.config.max_cost:
+                self._handle_breach("cost", self.config.max_cost, current_cost)
+
+        if self.config.max_tokens is not None:
+            current_tokens = self.tracker.total_tokens
+            if current_tokens >= self.config.max_tokens:
+                self._handle_breach("tokens", self.config.max_tokens, current_tokens)
+
+        if self.config.max_requests is not None:
+            current_requests = self.tracker.request_count
+            if current_requests >= self.config.max_requests:
+                self._handle_breach("requests", self.config.max_requests, current_requests)
+
+    def _handle_breach(self, limit_type: str, limit: float, current: float) -> None:
+        """Raise or warn (once per breach type) about an exceeded limit."""
+        if self.config.on_exceeded == "warn":
+            if limit_type not in self._warned_types:
+                self._warned_types.add(limit_type)
+                logger.warning(
+                    "Budget limit reached for %s: current=%s, limit=%s. "
+                    "Requests will continue because on_exceeded='warn'.",
+                    limit_type,
+                    current,
+                    limit,
+                )
+            return
+
+        raise BudgetExceededError(
+            f"Budget limit reached for {limit_type}: current={current}, limit={limit}",
+            limit_type=limit_type,
+            limit=limit,
+            current=current,
+        )

--- a/justllms/monitoring/usage.py
+++ b/justllms/monitoring/usage.py
@@ -1,0 +1,185 @@
+"""Usage tracking for completions across providers and models."""
+
+import threading
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Deque, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from justllms.core.models import Usage
+
+
+@dataclass
+class UsageRecord:
+    """A single recorded completion's usage details."""
+
+    timestamp: datetime
+    provider: str
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    cost: float
+    streamed: bool = False
+
+
+def _empty_bucket() -> Dict[str, Any]:
+    return {
+        "requests": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cost": 0.0,
+    }
+
+
+@dataclass
+class _Totals:
+    """Running totals kept separately from the (capped) records list."""
+
+    requests: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost: float = 0.0
+    by_provider: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    by_model: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+
+class UsageTracker:
+    """Thread-safe accumulator of per-request usage and cost.
+
+    Records every completion (token counts and estimated cost) and maintains
+    running totals plus per-provider and per-model breakdowns. Individual
+    records are kept in a ring buffer capped at ``max_records`` so
+    long-running applications do not grow unbounded; running totals remain
+    accurate even after old records are trimmed.
+    """
+
+    def __init__(self, max_records: int = 10000):
+        """Initialize the tracker.
+
+        Args:
+            max_records: Maximum number of individual UsageRecord entries to
+                retain. Older records are discarded first. Totals and
+                breakdowns are unaffected by trimming.
+        """
+        self._lock = threading.Lock()
+        self._records: Deque[UsageRecord] = deque(maxlen=max_records)
+        self._totals = _Totals()
+
+    def record(
+        self,
+        provider: str,
+        model: str,
+        usage: Optional["Usage"],
+        streamed: bool = False,
+    ) -> None:
+        """Record usage for a completed request.
+
+        Tolerates ``usage=None`` (the request is still counted, with zero
+        tokens/cost) and missing ``estimated_cost`` (treated as 0.0).
+
+        Args:
+            provider: Provider name (e.g. "openai").
+            model: Model identifier used for the request.
+            usage: Usage object from the response, or None if unavailable.
+            streamed: Whether the request was a streaming completion.
+        """
+        prompt_tokens = usage.prompt_tokens if usage else 0
+        completion_tokens = usage.completion_tokens if usage else 0
+        total_tokens = usage.total_tokens if usage else 0
+        cost = (usage.estimated_cost if usage and usage.estimated_cost else None) or 0.0
+
+        entry = UsageRecord(
+            timestamp=datetime.now(timezone.utc),
+            provider=provider,
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            cost=cost,
+            streamed=streamed,
+        )
+
+        with self._lock:
+            self._records.append(entry)
+            self._totals.requests += 1
+            self._totals.prompt_tokens += prompt_tokens
+            self._totals.completion_tokens += completion_tokens
+            self._totals.total_tokens += total_tokens
+            self._totals.cost += cost
+
+            for bucket_map, key in (
+                (self._totals.by_provider, provider),
+                (self._totals.by_model, f"{provider}/{model}"),
+            ):
+                bucket = bucket_map.setdefault(key, _empty_bucket())
+                bucket["requests"] += 1
+                bucket["prompt_tokens"] += prompt_tokens
+                bucket["completion_tokens"] += completion_tokens
+                bucket["total_tokens"] += total_tokens
+                bucket["cost"] += cost
+
+    @property
+    def total_cost(self) -> float:
+        """Cumulative estimated cost (USD) across all recorded requests."""
+        with self._lock:
+            return self._totals.cost
+
+    @property
+    def total_tokens(self) -> int:
+        """Cumulative total tokens across all recorded requests."""
+        with self._lock:
+            return self._totals.total_tokens
+
+    @property
+    def total_prompt_tokens(self) -> int:
+        """Cumulative prompt tokens across all recorded requests."""
+        with self._lock:
+            return self._totals.prompt_tokens
+
+    @property
+    def total_completion_tokens(self) -> int:
+        """Cumulative completion tokens across all recorded requests."""
+        with self._lock:
+            return self._totals.completion_tokens
+
+    @property
+    def request_count(self) -> int:
+        """Number of recorded requests."""
+        with self._lock:
+            return self._totals.requests
+
+    def get_summary(self) -> Dict[str, Any]:
+        """Get aggregated usage totals with per-provider/per-model breakdowns.
+
+        Returns:
+            Dict with total_cost, total_tokens, total_prompt_tokens,
+            total_completion_tokens, request_count, plus "by_provider" and
+            "by_model" breakdowns (requests, tokens, cost each).
+        """
+        with self._lock:
+            return {
+                "total_cost": self._totals.cost,
+                "total_tokens": self._totals.total_tokens,
+                "total_prompt_tokens": self._totals.prompt_tokens,
+                "total_completion_tokens": self._totals.completion_tokens,
+                "request_count": self._totals.requests,
+                "by_provider": {
+                    name: dict(bucket) for name, bucket in self._totals.by_provider.items()
+                },
+                "by_model": {name: dict(bucket) for name, bucket in self._totals.by_model.items()},
+            }
+
+    def get_records(self) -> List[UsageRecord]:
+        """Get a copy of the retained usage records (newest last)."""
+        with self._lock:
+            return list(self._records)
+
+    def reset(self) -> None:
+        """Clear all records and reset totals to zero."""
+        with self._lock:
+            self._records.clear()
+            self._totals = _Totals()

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,350 @@
+"""Tests for usage tracking and budget limits."""
+
+import logging
+import threading
+from typing import Any, Dict, Iterator, List, Optional
+
+import pytest
+
+from justllms import Client
+from justllms.core.base import BaseProvider, BaseResponse
+from justllms.core.models import Choice, Message, ModelInfo, ProviderConfig, Role, Usage
+from justllms.core.streaming import StreamChunk, SyncStreamResponse
+from justllms.exceptions import BudgetExceededError
+from justllms.monitoring import BudgetConfig, BudgetManager, UsageTracker
+
+# Cost per call with the fake provider's pricing and usage below:
+# 100/1000 * 0.01 + 50/1000 * 0.02 = 0.002
+EXPECTED_COST_PER_CALL = 0.002
+
+
+def make_usage(prompt: int = 100, completion: int = 50, cost: Optional[float] = None) -> Usage:
+    return Usage(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=prompt + completion,
+        estimated_cost=cost,
+    )
+
+
+class FakeProvider(BaseProvider):
+    """Minimal provider returning canned responses with usage."""
+
+    requires_api_key = False
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    def get_available_models(self) -> Dict[str, ModelInfo]:
+        return {
+            "fake-model": ModelInfo(
+                name="fake-model",
+                provider="fake",
+                cost_per_1k_prompt_tokens=0.01,
+                cost_per_1k_completion_tokens=0.02,
+            )
+        }
+
+    def complete(
+        self,
+        messages: List[Message],
+        model: str,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
+    ) -> BaseResponse:
+        return BaseResponse(
+            id="resp-1",
+            model=model,
+            choices=[
+                Choice(
+                    index=0,
+                    message=Message(role=Role.ASSISTANT, content="hello"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=make_usage(),
+        )
+
+
+class FakeStreamingProvider(FakeProvider):
+    """Fake provider that supports streaming."""
+
+    def supports_streaming(self) -> bool:
+        return True
+
+    def supports_streaming_for_model(self, model: str) -> bool:
+        return True
+
+    def stream(
+        self,
+        messages: List[Message],
+        model: str,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
+    ) -> SyncStreamResponse:
+        def chunks() -> Iterator[StreamChunk]:
+            yield StreamChunk(content="hel")
+            yield StreamChunk(content="lo", finish_reason="stop", usage=make_usage())
+
+        return SyncStreamResponse(
+            provider=self, model=model, messages=messages, raw_stream=chunks()
+        )
+
+
+def make_client(
+    provider: Optional[BaseProvider] = None, config: Optional[Dict[str, Any]] = None
+) -> Client:
+    provider = provider or FakeProvider(ProviderConfig(name="fake"))
+    return Client(config=config or {"providers": {}}, providers={"fake": provider})
+
+
+MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+class TestUsageTracker:
+    def test_record_and_totals(self) -> None:
+        tracker = UsageTracker()
+        tracker.record("openai", "gpt-4o", make_usage(100, 50, cost=0.5))
+        tracker.record("openai", "gpt-4o-mini", make_usage(10, 5, cost=0.1))
+        tracker.record("google", "gemini-pro", make_usage(20, 10, cost=0.2), streamed=True)
+
+        assert tracker.request_count == 3
+        assert tracker.total_prompt_tokens == 130
+        assert tracker.total_completion_tokens == 65
+        assert tracker.total_tokens == 195
+        assert tracker.total_cost == pytest.approx(0.8)
+
+        records = tracker.get_records()
+        assert len(records) == 3
+        assert records[2].streamed is True
+        assert records[0].provider == "openai"
+        assert records[0].cost == pytest.approx(0.5)
+
+    def test_summary_breakdowns(self) -> None:
+        tracker = UsageTracker()
+        tracker.record("openai", "gpt-4o", make_usage(100, 50, cost=0.5))
+        tracker.record("openai", "gpt-4o", make_usage(100, 50, cost=0.5))
+        tracker.record("google", "gemini-pro", make_usage(20, 10, cost=0.2))
+
+        summary = tracker.get_summary()
+        assert summary["request_count"] == 3
+        assert summary["total_cost"] == pytest.approx(1.2)
+        assert summary["by_provider"]["openai"]["requests"] == 2
+        assert summary["by_provider"]["openai"]["cost"] == pytest.approx(1.0)
+        assert summary["by_provider"]["google"]["total_tokens"] == 30
+        assert summary["by_model"]["openai/gpt-4o"]["requests"] == 2
+        assert summary["by_model"]["google/gemini-pro"]["cost"] == pytest.approx(0.2)
+
+    def test_none_usage_tolerated(self) -> None:
+        tracker = UsageTracker()
+        tracker.record("openai", "gpt-4o", None)
+        tracker.record("openai", "gpt-4o", make_usage(10, 5))  # no estimated_cost
+
+        assert tracker.request_count == 2
+        assert tracker.total_tokens == 15
+        assert tracker.total_cost == 0.0
+
+    def test_reset(self) -> None:
+        tracker = UsageTracker()
+        tracker.record("openai", "gpt-4o", make_usage(100, 50, cost=0.5))
+        tracker.reset()
+
+        assert tracker.request_count == 0
+        assert tracker.total_cost == 0.0
+        assert tracker.get_records() == []
+        assert tracker.get_summary()["by_provider"] == {}
+
+    def test_max_records_trimming_keeps_totals(self) -> None:
+        tracker = UsageTracker(max_records=5)
+        for _ in range(10):
+            tracker.record("openai", "gpt-4o", make_usage(10, 5, cost=0.01))
+
+        assert len(tracker.get_records()) == 5
+        assert tracker.request_count == 10
+        assert tracker.total_tokens == 150
+        assert tracker.total_cost == pytest.approx(0.1)
+
+    def test_concurrent_records(self) -> None:
+        tracker = UsageTracker()
+        n_threads, n_records = 8, 50
+
+        def worker() -> None:
+            for _ in range(n_records):
+                tracker.record("openai", "gpt-4o", make_usage(10, 5, cost=0.01))
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        total = n_threads * n_records
+        assert tracker.request_count == total
+        assert tracker.total_tokens == total * 15
+        assert tracker.total_cost == pytest.approx(total * 0.01)
+        assert tracker.get_summary()["by_provider"]["openai"]["requests"] == total
+
+
+class TestBudgetManager:
+    def test_no_limits_never_raises(self) -> None:
+        tracker = UsageTracker()
+        manager = BudgetManager(BudgetConfig(), tracker)
+        for _ in range(5):
+            tracker.record("openai", "gpt-4o", make_usage(1000, 1000, cost=100.0))
+            manager.check()
+
+    def test_max_cost_exceeded(self) -> None:
+        tracker = UsageTracker()
+        manager = BudgetManager(BudgetConfig(max_cost=1.0), tracker)
+        manager.check()  # under limit, fine
+
+        tracker.record("openai", "gpt-4o", make_usage(100, 50, cost=1.5))
+        with pytest.raises(BudgetExceededError) as exc_info:
+            manager.check()
+        assert exc_info.value.limit_type == "cost"
+        assert exc_info.value.limit == 1.0
+        assert exc_info.value.current == pytest.approx(1.5)
+
+    def test_max_tokens_exceeded(self) -> None:
+        tracker = UsageTracker()
+        manager = BudgetManager(BudgetConfig(max_tokens=100), tracker)
+        tracker.record("openai", "gpt-4o", make_usage(80, 40))
+        with pytest.raises(BudgetExceededError) as exc_info:
+            manager.check()
+        assert exc_info.value.limit_type == "tokens"
+        assert exc_info.value.current == 120
+
+    def test_max_requests_exceeded(self) -> None:
+        tracker = UsageTracker()
+        manager = BudgetManager(BudgetConfig(max_requests=2), tracker)
+        tracker.record("openai", "gpt-4o", make_usage())
+        manager.check()
+        tracker.record("openai", "gpt-4o", make_usage())
+        with pytest.raises(BudgetExceededError) as exc_info:
+            manager.check()
+        assert exc_info.value.limit_type == "requests"
+
+    def test_disabled_budget_never_raises(self) -> None:
+        tracker = UsageTracker()
+        manager = BudgetManager(BudgetConfig(enabled=False, max_requests=1), tracker)
+        tracker.record("openai", "gpt-4o", make_usage())
+        manager.check()
+
+    def test_warn_mode_logs_once_per_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        tracker = UsageTracker()
+        manager = BudgetManager(BudgetConfig(max_requests=1, on_exceeded="warn"), tracker)
+        tracker.record("openai", "gpt-4o", make_usage())
+
+        with caplog.at_level(logging.WARNING, logger="justllms.monitoring.budget"):
+            manager.check()
+            manager.check()
+
+        warnings = [r for r in caplog.records if "Budget limit reached" in r.message]
+        assert len(warnings) == 1
+        assert "requests" in warnings[0].message
+
+
+class TestClientIntegration:
+    def test_usage_recorded_for_completions(self) -> None:
+        client = make_client()
+        for _ in range(2):
+            response = client.completion.create(
+                messages=MESSAGES, provider="fake", model="fake-model"
+            )
+            assert response.usage is not None
+            assert response.usage.estimated_cost == pytest.approx(EXPECTED_COST_PER_CALL)
+
+        assert client.usage.request_count == 2
+        assert client.usage.total_cost == pytest.approx(2 * EXPECTED_COST_PER_CALL)
+
+        summary = client.get_usage_summary()
+        assert summary["request_count"] == 2
+        assert summary["by_model"]["fake/fake-model"]["requests"] == 2
+
+        client.reset_usage()
+        assert client.usage.request_count == 0
+
+    def test_budget_blocks_second_request(self) -> None:
+        client = make_client(config={"providers": {}, "budget": {"max_requests": 1}})
+        client.completion.create(messages=MESSAGES, provider="fake", model="fake-model")
+
+        with pytest.raises(BudgetExceededError) as exc_info:
+            client.completion.create(messages=MESSAGES, provider="fake", model="fake-model")
+        assert exc_info.value.limit_type == "requests"
+        assert client.usage.request_count == 1
+
+    def test_budget_warn_mode_allows_requests(self, caplog: pytest.LogCaptureFixture) -> None:
+        client = make_client(
+            config={"providers": {}, "budget": {"max_requests": 1, "on_exceeded": "warn"}}
+        )
+        with caplog.at_level(logging.WARNING, logger="justllms.monitoring.budget"):
+            client.completion.create(messages=MESSAGES, provider="fake", model="fake-model")
+            client.completion.create(messages=MESSAGES, provider="fake", model="fake-model")
+
+        assert client.usage.request_count == 2
+        assert any("Budget limit reached" in r.message for r in caplog.records)
+
+    def test_budget_max_cost_via_client(self) -> None:
+        client = make_client(
+            config={"providers": {}, "budget": {"max_cost": EXPECTED_COST_PER_CALL / 2}}
+        )
+        client.completion.create(messages=MESSAGES, provider="fake", model="fake-model")
+        with pytest.raises(BudgetExceededError) as exc_info:
+            client.completion.create(messages=MESSAGES, provider="fake", model="fake-model")
+        assert exc_info.value.limit_type == "cost"
+
+    def test_streaming_usage_recorded(self) -> None:
+        client = make_client(provider=FakeStreamingProvider(ProviderConfig(name="fake")))
+        stream = client.completion.create(
+            messages=MESSAGES, provider="fake", model="fake-model", stream=True
+        )
+        content = "".join(chunk.content or "" for chunk in stream)
+        assert content == "hello"
+
+        final = stream.get_final_response()
+        assert final.usage is not None
+
+        # Calling get_final_response again must not double-record.
+        stream.get_final_response()
+
+        assert client.usage.request_count == 1
+        records = client.usage.get_records()
+        assert records[0].streamed is True
+        assert records[0].total_tokens == 150
+        assert client.usage.total_cost == pytest.approx(EXPECTED_COST_PER_CALL)
+
+
+class TestSyncStreamOnComplete:
+    def _make_stream(self, on_complete: Any) -> SyncStreamResponse:
+        provider = FakeStreamingProvider(ProviderConfig(name="fake"))
+
+        def chunks() -> Iterator[StreamChunk]:
+            yield StreamChunk(content="hi", finish_reason="stop", usage=make_usage())
+
+        return SyncStreamResponse(
+            provider=provider,
+            model="fake-model",
+            messages=[Message(role=Role.USER, content="hi")],
+            raw_stream=chunks(),
+            on_complete=on_complete,
+        )
+
+    def test_on_complete_fires_exactly_once(self) -> None:
+        calls: List[Any] = []
+        stream = self._make_stream(calls.append)
+
+        final = stream.get_final_response()
+        stream.get_final_response()
+        stream.get_final_response()
+
+        assert len(calls) == 1
+        assert calls[0].usage.total_tokens == final.usage.total_tokens
+
+    def test_on_complete_errors_are_swallowed(self) -> None:
+        def boom(_response: Any) -> None:
+            raise RuntimeError("callback exploded")
+
+        stream = self._make_stream(boom)
+        final = stream.get_final_response()  # must not raise
+        assert final.content == "hi"


### PR DESCRIPTION
## Summary

Adds first-class cost tracking and budget enforcement — one of the most-demanded LLM gateway capabilities (LiteLLM headlines it; every 2025/2026 gateway comparison lists cost attribution as a primary buying criterion). JustLLMs already computed per-response `estimated_cost`; this PR makes that data actionable.

### What's new

- **`UsageTracker`** (`justllms/monitoring/usage.py`): thread-safe accumulator attached to every `Client` as `client.usage`. Tracks requests, prompt/completion tokens, and cost with per-provider and per-model breakdowns. Ring-buffer record history (default 10k) keeps memory bounded while running totals stay exact.
- **`BudgetManager` + `BudgetConfig`** (`justllms/monitoring/budget.py`): optional `budget` config block with `max_cost`, `max_tokens`, `max_requests` limits and `on_exceeded: "raise" | "warn"`. Checks are pre-flight: the request that crosses a limit completes, the next one raises `BudgetExceededError`.
- **`BudgetExceededError`** with `limit_type` / `limit` / `current` fields, exported at top level.
- **Streaming usage capture**: `SyncStreamResponse` gained an `on_complete` callback that fires exactly once when the final response is built, so streamed requests are tracked too.
- Convenience APIs: `client.get_usage_summary()`, `client.reset_usage()`.

### Usage

```python
client = JustLLM({
    "providers": {"openai": {"api_key": "..."}},
    "budget": {"max_cost": 5.0, "on_exceeded": "raise"},
})

client.completion.create(messages=[...])
print(client.get_usage_summary())
# {"total_cost": 0.0042, "total_tokens": 815, "request_count": 1,
#  "by_provider": {...}, "by_model": {...}}
```

### Notes / limitations
- Tool-loop intermediate completions are not individually tracked (final response only) — documented in code.
- Streamed usage is recorded when `get_final_response()` is called.
- Budgets are per-client-instance (no cross-process persistence).

## Testing
- 19 new tests in `tests/test_monitoring.py` (tracker aggregation/threading/trimming, budget raise/warn semantics, client integration with stub providers, streaming callback)
- `ruff`, `black --check`, `mypy` (strict, `disallow_untyped_defs`) all clean

https://claude.ai/code/session_01DC8Ax6EFiFnCFsGEHhW3MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC8Ax6EFiFnCFsGEHhW3MH)_