### PR TITLE
feat: failure-driven provider fallback chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,75 @@ response = client.completion.create(
 )
 ```
 
+#### Failure-Driven Failover
+
+Beyond static selection, JustLLMs can automatically retry a request on the next
+provider/model in a fallback chain when the chosen provider fails (rate limit,
+server error, timeout, network error, or auth error):
+
+```python
+client = JustLLM({
+    "providers": {
+        "openai": {"api_key": "your-key"},
+        "anthropic": {"api_key": "your-key"},
+        "google": {"api_key": "your-key"}
+    },
+    "routing": {
+        # Ordered chain tried after the primary. Entries are "provider/model"
+        # or just "provider" (uses the provider's first available model).
+        "fallback_chain": ["anthropic/claude-3-5-sonnet-20241022", "google"],
+
+        # Or, with an empty chain, derive it automatically from all other
+        # configured providers:
+        "auto_fallback": False,
+
+        # Total attempts including the primary (default: 3)
+        "max_fallback_attempts": 3,
+
+        # Error categories that trigger failover (default: all of these)
+        "fallback_on": ["rate_limit", "server_error", "timeout", "connection", "auth"]
+    }
+})
+```
+
+Equivalent YAML config:
+
+```yaml
+routing:
+  fallback_chain:
+    - anthropic/claude-3-5-sonnet-20241022
+    - google
+  auto_fallback: false
+  max_fallback_attempts: 3
+  fallback_on: [rate_limit, server_error, timeout, connection, auth]
+```
+
+Non-retryable errors (e.g. 400 bad request, 404 unknown model, validation
+errors) are raised immediately without failover. You can disable failover for
+a single request:
+
+```python
+response = client.completion.create(
+    messages=[{"role": "user", "content": "Hello"}],
+    fallback=False  # raise immediately if the chosen provider fails
+)
+```
+
+When failover engages, the response tells you what happened:
+
+```python
+response.provider           # actual provider that served the request
+response.model              # actual model used
+response.fallback_used      # True when at least one attempt failed
+response.fallback_attempts  # per-attempt records: provider, model, error,
+                            # error_category, succeeded, duration_ms
+```
+
+Note: failure-driven failover applies to non-streaming, non-tool requests.
+Streaming and tool-calling requests keep their current behavior, though
+HTTP-level retries (3 attempts with exponential backoff on 429/408/5xx and
+network errors) still apply to every request.
+
 ## Side-by-Side Model Comparison
 
 Compare multiple LLM providers and models simultaneously with our interactive SXS (Side-by-Side) comparison tool. Perfect for evaluating model performance, testing prompts, and making informed decisions about which models to use.

--- a/justllms/config/config.py
+++ b/justllms/config/config.py
@@ -2,9 +2,9 @@ import contextlib
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -27,6 +27,22 @@ class RoutingConfig(BaseModel):
 
     fallback_provider: Optional[str] = None
     fallback_model: Optional[str] = None
+
+    """Ordered failover chain. Entries are "provider/model" or bare "provider"
+    (which resolves to the provider's first available model)."""
+    fallback_chain: List[str] = Field(default_factory=list)
+
+    """When True and fallback_chain is empty, derive a chain at request time
+    from all other configured providers (their first available model)."""
+    auto_fallback: bool = False
+
+    """Total attempts including the primary provider."""
+    max_fallback_attempts: int = 3
+
+    """Error categories that trigger failover to the next provider."""
+    fallback_on: List[str] = Field(
+        default_factory=lambda: ["rate_limit", "server_error", "timeout", "connection", "auth"]
+    )
 
     """max execution time per tool"""
     tool_timeout: float = 120.0

--- a/justllms/core/client.py
+++ b/justllms/core/client.py
@@ -6,6 +6,7 @@ from justllms.core.base import BaseProvider, BaseResponse
 from justllms.core.completion import Completion, CompletionResponse
 from justllms.core.models import Message, ProviderConfig
 from justllms.exceptions import ConfigurationError, ProviderError
+from justllms.reliability import FallbackExecutor
 from justllms.routing import Router
 
 logger = logging.getLogger(__name__)
@@ -224,6 +225,49 @@ class Client:
             **response.raw_response,
         )
 
+    def _complete_with_fallback(
+        self,
+        messages: List[Message],
+        provider_name: str,
+        selected_model: str,
+        fallback_override: Optional[bool],
+        **kwargs: Any,
+    ) -> CompletionResponse:
+        """Run a non-streaming completion with optional failure-driven failover.
+
+        Args:
+            messages: List of conversation messages to process.
+            provider_name: Primary provider to attempt first.
+            selected_model: Primary model to attempt first.
+            fallback_override: Per-request failover override. False disables
+                failover, True forces it, None uses the routing configuration.
+            **kwargs: Additional parameters passed to the provider's complete method.
+
+        Returns:
+            CompletionResponse from the first provider in the chain that succeeds,
+            with fallback metadata populated when failover engaged.
+        """
+        executor = FallbackExecutor(self.config.routing)
+        use_fallback = fallback_override if fallback_override is not None else executor.enabled
+
+        def _call(name: str, model_name: str) -> CompletionResponse:
+            provider_instance = self.providers[name]
+            response = provider_instance.complete(messages=messages, model=model_name, **kwargs)
+            self._estimate_and_set_cost(response, provider_instance, model_name)
+            return self._wrap_completion_response(response, name)
+
+        if not use_fallback:
+            return _call(provider_name, selected_model)
+
+        chain = executor.build_chain((provider_name, selected_model), self.providers)
+        completion, attempts = executor.execute(chain, _call)
+
+        if any(not attempt.succeeded for attempt in attempts):
+            completion.fallback_used = True
+            completion.fallback_attempts = [attempt.to_dict() for attempt in attempts]
+
+        return completion
+
     def _create_completion(
         self,
         messages: List[Message],
@@ -235,7 +279,10 @@ class Client:
         """Create a completion with automatic fallback support.
 
         Uses configured fallback provider/model or first available provider
-        if no specific model is requested.
+        if no specific model is requested. When a fallback chain is configured
+        (routing.fallback_chain or routing.auto_fallback), non-streaming
+        non-tool requests automatically fail over to the next provider/model
+        on retryable errors.
 
         Args:
             messages: List of conversation messages to process.
@@ -245,6 +292,8 @@ class Client:
             stream: If True, returns streaming response instead of CompletionResponse.
             **kwargs: Additional parameters passed to the provider's complete method.
                      Common parameters: temperature, max_tokens, top_p, etc.
+                     'fallback' (Optional[bool]) is consumed here as a per-request
+                     failover override and never forwarded to providers.
 
         Returns:
             CompletionResponse or StreamResponse depending on stream parameter.
@@ -256,6 +305,9 @@ class Client:
                           completion request fails, or if streaming is requested
                           but the provider doesn't support it.
         """
+        # Per-request failover override; popped so it never reaches provider payloads.
+        fallback_override: Optional[bool] = kwargs.pop("fallback", None)
+
         # Check if tools are provided
         tools = kwargs.pop("tools", None)
         if tools and stream:
@@ -342,12 +394,15 @@ class Client:
                 # Stream with specified provider
                 return provider_instance.stream(messages=messages, model=selected_model, **kwargs)
             else:
-                # Non-streaming with specified provider
-                response = provider_instance.complete(
-                    messages=messages, model=selected_model, **kwargs
+                # Non-streaming with specified provider; explicit provider is the
+                # primary and the configured fallback chain still applies after it.
+                return self._complete_with_fallback(
+                    messages=messages,
+                    provider_name=provider,
+                    selected_model=selected_model,
+                    fallback_override=fallback_override,
+                    **kwargs,
                 )
-                self._estimate_and_set_cost(response, provider_instance, selected_model)
-                return self._wrap_completion_response(response, provider)
 
         if stream:
             provider_name, selected_model = self.router.route_streaming(
@@ -363,7 +418,10 @@ class Client:
                 messages=messages, model=model, providers=self.providers, **kwargs
             )
 
-            provider_instance = self.providers[provider_name]
-            response = provider_instance.complete(messages=messages, model=selected_model, **kwargs)
-            self._estimate_and_set_cost(response, provider_instance, selected_model)
-            return self._wrap_completion_response(response, provider_name)
+            return self._complete_with_fallback(
+                messages=messages,
+                provider_name=provider_name,
+                selected_model=selected_model,
+                fallback_override=fallback_override,
+                **kwargs,
+            )

--- a/justllms/core/completion.py
+++ b/justllms/core/completion.py
@@ -36,6 +36,8 @@ class CompletionResponse(BaseResponse):
         self.tool_execution_history: Optional[List[Any]] = None
         self.tools_used: Optional[List[str]] = None
         self.tool_execution_cost: Optional[float] = None
+        self.fallback_used: bool = False
+        self.fallback_attempts: Optional[List[Dict[str, Any]]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert response to dictionary."""
@@ -66,6 +68,8 @@ class CompletionResponse(BaseResponse):
             "created": self.created,
             "system_fingerprint": self.system_fingerprint,
             "provider": self.provider,
+            "fallback_used": self.fallback_used,
+            "fallback_attempts": self.fallback_attempts,
         }
 
     @property
@@ -106,6 +110,7 @@ class Completion:
         seed: Optional[int] = None,
         user: Optional[str] = None,
         timeout: Optional[float] = None,
+        fallback: Optional[bool] = None,
         **kwargs: Any,
     ) -> CompletionResponse: ...
 
@@ -132,6 +137,7 @@ class Completion:
         seed: Optional[int] = None,
         user: Optional[str] = None,
         timeout: Optional[float] = None,
+        fallback: Optional[bool] = None,
         **kwargs: Any,
     ) -> "SyncStreamResponse": ...
 
@@ -157,6 +163,7 @@ class Completion:
         seed: Optional[int] = None,
         user: Optional[str] = None,
         timeout: Optional[float] = None,
+        fallback: Optional[bool] = None,
         **kwargs: Any,
     ) -> "Union[CompletionResponse, SyncStreamResponse]":
         """Create a completion with automatic fallbacks.
@@ -191,6 +198,11 @@ class Completion:
                 seed: Random seed for deterministic outputs (OpenAI).
                 user: End-user identifier.
                 timeout: Request timeout in seconds. If None, no timeout is enforced.
+                fallback: Per-request failover override. False disables provider
+                    failover for this call; None uses the routing configuration
+                    (failover is active when fallback_chain is non-empty or
+                    auto_fallback is true). Applies to non-streaming, non-tool
+                    requests only.
 
         Returns:
             CompletionResponse: The model's response.
@@ -241,6 +253,7 @@ class Completion:
             "seed": seed,
             "user": user,
             "timeout": timeout,
+            "fallback": fallback,
             **kwargs,
         }
 

--- a/justllms/reliability/__init__.py
+++ b/justllms/reliability/__init__.py
@@ -1,0 +1,11 @@
+from justllms.reliability.fallback import (
+    FallbackAttempt,
+    FallbackExecutor,
+    classify_error,
+)
+
+__all__ = [
+    "FallbackAttempt",
+    "FallbackExecutor",
+    "classify_error",
+]

--- a/justllms/reliability/fallback.py
+++ b/justllms/reliability/fallback.py
@@ -1,0 +1,300 @@
+"""Failure-driven provider failover.
+
+This module implements the failover layer that sits above per-request HTTP
+retries (see ``BaseProvider._make_http_request``): when a provider ultimately
+fails with a retryable category of error, the next (provider, model) pair in
+the fallback chain is tried.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+import httpx
+
+from justllms.exceptions import (
+    AuthenticationError,
+    ProviderError,
+    RateLimitError,
+)
+from justllms.exceptions import (
+    TimeoutError as JustLLMsTimeoutError,
+)
+
+if TYPE_CHECKING:
+    from justllms.core.base import BaseProvider
+    from justllms.core.completion import CompletionResponse
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FALLBACK_ON = ["rate_limit", "server_error", "timeout", "connection", "auth"]
+
+
+def classify_error(exc: Exception) -> Optional[str]:
+    """Classify an exception into a failover category.
+
+    Args:
+        exc: The exception raised by a provider call.
+
+    Returns:
+        One of "rate_limit", "server_error", "timeout", "connection", "auth",
+        or None when the error should NOT trigger failover (e.g. validation
+        errors or 4xx client errors that would fail on every provider).
+    """
+    # Specific justllms exception subclasses first (they subclass ProviderError).
+    if isinstance(exc, RateLimitError):
+        return "rate_limit"
+    if isinstance(exc, AuthenticationError):
+        return "auth"
+    if isinstance(exc, JustLLMsTimeoutError):
+        return "timeout"
+
+    # httpx network errors. TimeoutException subclasses RequestError, so check it first.
+    if isinstance(exc, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(exc, httpx.RequestError):
+        return "connection"
+
+    if isinstance(exc, ProviderError):
+        status = getattr(exc, "status_code", None)
+        if not isinstance(status, int):
+            return None
+        if status == 429:
+            return "rate_limit"
+        if status == 408:
+            return "timeout"
+        if status in (401, 403):
+            return "auth"
+        if 500 <= status < 600:
+            return "server_error"
+        # Other 4xx (400 bad request, 404 model not found, ...) are caller
+        # errors that would fail on every provider: do not fail over.
+        return None
+
+    # ValidationError, ValueError, ConfigurationError, anything unknown.
+    return None
+
+
+@dataclass
+class FallbackAttempt:
+    """Record of a single attempt in a fallback chain."""
+
+    provider: str
+    model: str
+    error: Optional[str] = None
+    error_category: Optional[str] = None
+    succeeded: bool = False
+    duration_ms: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the attempt for response metadata."""
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "error": self.error,
+            "error_category": self.error_category,
+            "succeeded": self.succeeded,
+            "duration_ms": self.duration_ms,
+        }
+
+
+def _read_setting(config: Any, key: str, default: Any) -> Any:
+    """Read a setting from a dict-like or attribute-style config object."""
+    if config is None:
+        return default
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+class FallbackExecutor:
+    """Builds and executes failure-driven fallback chains."""
+
+    def __init__(self, routing_config: Any = None) -> None:
+        """Initialize from a routing config (RoutingConfig, dict, or None).
+
+        Args:
+            routing_config: Object or mapping providing fallback_chain,
+                auto_fallback, max_fallback_attempts and fallback_on.
+        """
+        self.fallback_chain: List[str] = list(
+            _read_setting(routing_config, "fallback_chain", []) or []
+        )
+        self.auto_fallback: bool = bool(_read_setting(routing_config, "auto_fallback", False))
+        self.max_fallback_attempts: int = int(
+            _read_setting(routing_config, "max_fallback_attempts", 3)
+        )
+        self.fallback_on: List[str] = list(
+            _read_setting(routing_config, "fallback_on", DEFAULT_FALLBACK_ON) or []
+        )
+
+    @property
+    def enabled(self) -> bool:
+        """Whether failover is active by configuration."""
+        return bool(self.fallback_chain) or self.auto_fallback
+
+    def _resolve_entry(
+        self, entry: str, providers: Dict[str, "BaseProvider"]
+    ) -> Optional[Tuple[str, str]]:
+        """Resolve a chain entry ("provider/model" or "provider") to a tuple.
+
+        Returns None (with a logged warning) for unknown providers, invalid
+        models, or providers with no available models.
+        """
+        if "/" in entry:
+            provider_name, model_name = entry.split("/", 1)
+        else:
+            provider_name, model_name = entry, ""
+
+        provider = providers.get(provider_name)
+        if provider is None:
+            logger.warning(
+                "Fallback chain entry '%s' skipped: provider '%s' is not available",
+                entry,
+                provider_name,
+            )
+            return None
+
+        if model_name:
+            if not provider.validate_model(model_name):
+                logger.warning(
+                    "Fallback chain entry '%s' skipped: model '%s' not found in provider '%s'",
+                    entry,
+                    model_name,
+                    provider_name,
+                )
+                return None
+            return provider_name, model_name
+
+        models = provider.get_available_models()
+        if not models:
+            logger.warning(
+                "Fallback chain entry '%s' skipped: provider '%s' has no available models",
+                entry,
+                provider_name,
+            )
+            return None
+        return provider_name, next(iter(models.keys()))
+
+    def build_chain(
+        self,
+        primary: Tuple[str, str],
+        providers: Dict[str, "BaseProvider"],
+    ) -> List[Tuple[str, str]]:
+        """Build the ordered (provider, model) chain starting with the primary.
+
+        Args:
+            primary: The (provider, model) pair selected for the request.
+            providers: Available provider instances keyed by name.
+
+        Returns:
+            Chain of unique (provider, model) pairs, primary first, truncated
+            to max_fallback_attempts entries.
+        """
+        chain: List[Tuple[str, str]] = [primary]
+        seen = {primary}
+
+        for entry in self.fallback_chain:
+            resolved = self._resolve_entry(entry, providers)
+            if resolved is None or resolved in seen:
+                continue
+            chain.append(resolved)
+            seen.add(resolved)
+
+        if self.auto_fallback and not self.fallback_chain:
+            for provider_name, provider in providers.items():
+                if provider_name == primary[0]:
+                    continue
+                models = provider.get_available_models()
+                if not models:
+                    continue
+                candidate = (provider_name, next(iter(models.keys())))
+                if candidate in seen:
+                    continue
+                chain.append(candidate)
+                seen.add(candidate)
+
+        max_attempts = max(1, self.max_fallback_attempts)
+        return chain[:max_attempts]
+
+    def execute(
+        self,
+        chain: List[Tuple[str, str]],
+        call: Callable[[str, str], "CompletionResponse"],
+    ) -> Tuple["CompletionResponse", List[FallbackAttempt]]:
+        """Try each (provider, model) pair in the chain until one succeeds.
+
+        Args:
+            chain: Ordered chain of (provider, model) pairs to attempt.
+            call: Callable invoked as call(provider_name, model_name) that
+                performs the completion and returns a CompletionResponse.
+
+        Returns:
+            Tuple of (successful response, list of all attempts including
+            failed ones and the successful one).
+
+        Raises:
+            ValueError: If the chain is empty.
+            Exception: The original error when it is non-retryable, not in
+                fallback_on, or when the last attempt fails.
+        """
+        if not chain:
+            raise ValueError("Fallback chain is empty")
+
+        attempts: List[FallbackAttempt] = []
+
+        for index, (provider_name, model_name) in enumerate(chain):
+            start = time.monotonic()
+            try:
+                response = call(provider_name, model_name)
+            except Exception as exc:
+                duration_ms = (time.monotonic() - start) * 1000.0
+                category = classify_error(exc)
+                attempts.append(
+                    FallbackAttempt(
+                        provider=provider_name,
+                        model=model_name,
+                        error=str(exc),
+                        error_category=category,
+                        succeeded=False,
+                        duration_ms=duration_ms,
+                    )
+                )
+
+                is_last = index == len(chain) - 1
+                if category is None or category not in self.fallback_on or is_last:
+                    if is_last and len(attempts) > 1:
+                        history = ", ".join(
+                            f"{a.provider}/{a.model} ({a.error_category or 'unclassified'})"
+                            for a in attempts
+                        )
+                        logger.warning(
+                            "All %d fallback attempts failed: %s", len(attempts), history
+                        )
+                    raise
+
+                next_provider, next_model = chain[index + 1]
+                logger.warning(
+                    "Provider %s failed (%s), falling back to %s/%s: %s",
+                    provider_name,
+                    category,
+                    next_provider,
+                    next_model,
+                    exc,
+                )
+                continue
+
+            duration_ms = (time.monotonic() - start) * 1000.0
+            attempts.append(
+                FallbackAttempt(
+                    provider=provider_name,
+                    model=model_name,
+                    succeeded=True,
+                    duration_ms=duration_ms,
+                )
+            )
+            return response, attempts
+
+        # Unreachable: the last failed attempt re-raises inside the loop.
+        raise RuntimeError("Fallback chain exhausted without raising")  # pragma: no cover

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,410 @@
+"""Tests for failure-driven provider fallback."""
+
+from typing import Any, Callable, Dict, List, Optional
+
+import httpx
+import pytest
+
+from justllms.core.base import BaseProvider, BaseResponse
+from justllms.core.client import Client
+from justllms.core.models import Choice, Message, ModelInfo, ProviderConfig, Role, Usage
+from justllms.exceptions import (
+    AuthenticationError,
+    ConfigurationError,
+    ProviderError,
+    RateLimitError,
+    ValidationError,
+)
+from justllms.exceptions import (
+    TimeoutError as JustLLMsTimeoutError,
+)
+from justllms.reliability import FallbackAttempt, FallbackExecutor, classify_error
+
+
+def make_response(model: str, content: str = "ok") -> BaseResponse:
+    """Build a minimal canned provider response."""
+    return BaseResponse(
+        id="resp-1",
+        model=model,
+        choices=[
+            Choice(
+                index=0,
+                message=Message(role=Role.ASSISTANT, content=content),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+class FakeProvider(BaseProvider):
+    """Configurable in-memory provider for tests."""
+
+    requires_api_key = False
+
+    def __init__(
+        self,
+        name: str,
+        models: List[str],
+        behavior: Optional[Callable[[str], BaseResponse]] = None,
+    ):
+        super().__init__(ProviderConfig(name=name))
+        self._name = name
+        self._models = models
+        self._behavior = behavior or (lambda model: make_response(model))
+        self.calls: List[Dict[str, Any]] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get_available_models(self) -> Dict[str, ModelInfo]:
+        return {m: ModelInfo(name=m, provider=self._name) for m in self._models}
+
+    def complete(
+        self,
+        messages: List[Message],
+        model: str,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
+    ) -> BaseResponse:
+        self.calls.append({"model": model, "kwargs": kwargs})
+        return self._behavior(model)
+
+
+def always_raise(exc: Exception) -> Callable[[str], BaseResponse]:
+    def _behavior(model: str) -> BaseResponse:
+        raise exc
+
+    return _behavior
+
+
+# ---------------------------------------------------------------------------
+# classify_error
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyError:
+    def test_rate_limit_error_instance(self):
+        assert classify_error(RateLimitError("slow down")) == "rate_limit"
+
+    def test_provider_error_429(self):
+        assert classify_error(ProviderError("err", status_code=429)) == "rate_limit"
+
+    @pytest.mark.parametrize("status", [500, 502, 503, 599])
+    def test_provider_error_5xx(self, status):
+        assert classify_error(ProviderError("err", status_code=status)) == "server_error"
+
+    def test_timeout_error_instance(self):
+        assert classify_error(JustLLMsTimeoutError("too slow")) == "timeout"
+
+    def test_httpx_timeout(self):
+        assert classify_error(httpx.ConnectTimeout("timed out")) == "timeout"
+
+    def test_provider_error_408(self):
+        assert classify_error(ProviderError("err", status_code=408)) == "timeout"
+
+    def test_httpx_connect_error(self):
+        assert classify_error(httpx.ConnectError("refused")) == "connection"
+
+    def test_httpx_request_error(self):
+        assert classify_error(httpx.RequestError("network")) == "connection"
+
+    def test_authentication_error_instance(self):
+        assert classify_error(AuthenticationError("bad key")) == "auth"
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_provider_error_auth_status(self, status):
+        assert classify_error(ProviderError("err", status_code=status)) == "auth"
+
+    @pytest.mark.parametrize("status", [400, 404, 422])
+    def test_provider_error_other_4xx_not_failover(self, status):
+        assert classify_error(ProviderError("err", status_code=status)) is None
+
+    def test_provider_error_without_status(self):
+        assert classify_error(ProviderError("err")) is None
+
+    def test_validation_error(self):
+        assert classify_error(ValidationError("bad input")) is None
+
+    def test_configuration_error(self):
+        assert classify_error(ConfigurationError("bad config")) is None
+
+    def test_plain_value_error(self):
+        assert classify_error(ValueError("nope")) is None
+
+
+# ---------------------------------------------------------------------------
+# build_chain
+# ---------------------------------------------------------------------------
+
+
+class TestBuildChain:
+    def make_providers(self) -> Dict[str, BaseProvider]:
+        return {
+            "a": FakeProvider("a", ["model-a1", "model-a2"]),
+            "b": FakeProvider("b", ["model-b"]),
+            "c": FakeProvider("c", ["model-c"]),
+        }
+
+    def test_explicit_chain_with_model_and_bare_provider(self):
+        executor = FallbackExecutor({"fallback_chain": ["b/model-b", "c"]})
+        chain = executor.build_chain(("a", "model-a1"), self.make_providers())
+        assert chain == [("a", "model-a1"), ("b", "model-b"), ("c", "model-c")]
+
+    def test_skips_unknown_provider_and_invalid_model(self):
+        executor = FallbackExecutor(
+            {"fallback_chain": ["nope/model-x", "b/wrong-model", "c/model-c"]}
+        )
+        chain = executor.build_chain(("a", "model-a1"), self.make_providers())
+        assert chain == [("a", "model-a1"), ("c", "model-c")]
+
+    def test_dedupes_primary(self):
+        executor = FallbackExecutor({"fallback_chain": ["a/model-a1", "b/model-b"]})
+        chain = executor.build_chain(("a", "model-a1"), self.make_providers())
+        assert chain == [("a", "model-a1"), ("b", "model-b")]
+
+    def test_auto_fallback_derives_chain_from_other_providers(self):
+        executor = FallbackExecutor({"auto_fallback": True})
+        chain = executor.build_chain(("b", "model-b"), self.make_providers())
+        assert chain[0] == ("b", "model-b")
+        assert set(chain[1:]) == {("a", "model-a1"), ("c", "model-c")}
+
+    def test_auto_fallback_ignored_when_chain_present(self):
+        executor = FallbackExecutor({"auto_fallback": True, "fallback_chain": ["c"]})
+        chain = executor.build_chain(("a", "model-a1"), self.make_providers())
+        assert chain == [("a", "model-a1"), ("c", "model-c")]
+
+    def test_max_fallback_attempts_truncation(self):
+        executor = FallbackExecutor(
+            {"fallback_chain": ["b/model-b", "c/model-c"], "max_fallback_attempts": 2}
+        )
+        chain = executor.build_chain(("a", "model-a1"), self.make_providers())
+        assert chain == [("a", "model-a1"), ("b", "model-b")]
+
+    def test_enabled_property(self):
+        assert not FallbackExecutor({}).enabled
+        assert FallbackExecutor({"fallback_chain": ["b"]}).enabled
+        assert FallbackExecutor({"auto_fallback": True}).enabled
+
+
+# ---------------------------------------------------------------------------
+# FallbackExecutor.execute
+# ---------------------------------------------------------------------------
+
+
+class TestExecute:
+    def test_success_first_try(self):
+        executor = FallbackExecutor({"fallback_chain": ["b/model-b"]})
+        chain = [("a", "model-a"), ("b", "model-b")]
+
+        def call(provider: str, model: str) -> Any:
+            return f"{provider}:{model}"
+
+        result, attempts = executor.execute(chain, call)
+        assert result == "a:model-a"
+        assert len(attempts) == 1
+        assert attempts[0].succeeded is True
+        assert attempts[0].error is None
+        assert not any(not a.succeeded for a in attempts)
+
+    def test_first_fails_429_second_succeeds(self):
+        executor = FallbackExecutor({"fallback_chain": ["b/model-b"]})
+        chain = [("a", "model-a"), ("b", "model-b")]
+
+        def call(provider: str, model: str) -> Any:
+            if provider == "a":
+                raise ProviderError("rate limited", status_code=429)
+            return f"{provider}:{model}"
+
+        result, attempts = executor.execute(chain, call)
+        assert result == "b:model-b"
+        assert len(attempts) == 2
+        assert attempts[0].provider == "a"
+        assert attempts[0].succeeded is False
+        assert attempts[0].error_category == "rate_limit"
+        assert "rate limited" in attempts[0].error
+        assert attempts[1].provider == "b"
+        assert attempts[1].succeeded is True
+
+    def test_all_fail_raises_last_error(self):
+        executor = FallbackExecutor({"fallback_chain": ["b/model-b"]})
+        chain = [("a", "model-a"), ("b", "model-b")]
+
+        def call(provider: str, model: str) -> Any:
+            if provider == "a":
+                raise ProviderError("a down", status_code=503)
+            raise ProviderError("b down", status_code=500)
+
+        with pytest.raises(ProviderError, match="b down"):
+            executor.execute(chain, call)
+
+    def test_non_retryable_error_raised_immediately(self):
+        executor = FallbackExecutor({"fallback_chain": ["b/model-b"]})
+        chain = [("a", "model-a"), ("b", "model-b")]
+        calls: List[str] = []
+
+        def call(provider: str, model: str) -> Any:
+            calls.append(provider)
+            raise ProviderError("bad request", status_code=400)
+
+        with pytest.raises(ProviderError, match="bad request"):
+            executor.execute(chain, call)
+        assert calls == ["a"]
+
+    def test_category_filtering_via_fallback_on(self):
+        executor = FallbackExecutor(
+            {"fallback_chain": ["b/model-b"], "fallback_on": ["server_error"]}
+        )
+        chain = [("a", "model-a"), ("b", "model-b")]
+        calls: List[str] = []
+
+        def call(provider: str, model: str) -> Any:
+            calls.append(provider)
+            raise ProviderError("rate limited", status_code=429)
+
+        with pytest.raises(ProviderError, match="rate limited"):
+            executor.execute(chain, call)
+        assert calls == ["a"]
+
+    def test_empty_chain_raises(self):
+        executor = FallbackExecutor({})
+        with pytest.raises(ValueError, match="empty"):
+            executor.execute([], lambda p, m: None)
+
+    def test_attempt_to_dict(self):
+        attempt = FallbackAttempt(
+            provider="a",
+            model="m",
+            error="boom",
+            error_category="server_error",
+            succeeded=False,
+            duration_ms=1.5,
+        )
+        assert attempt.to_dict() == {
+            "provider": "a",
+            "model": "m",
+            "error": "boom",
+            "error_category": "server_error",
+            "succeeded": False,
+            "duration_ms": 1.5,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Client end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestClientFallback:
+    def make_client(
+        self,
+        routing: Optional[Dict[str, Any]] = None,
+        provider_a: Optional[FakeProvider] = None,
+        provider_b: Optional[FakeProvider] = None,
+    ) -> Client:
+        provider_a = provider_a or FakeProvider(
+            "a",
+            ["model-a"],
+            behavior=always_raise(ProviderError("rate limited", status_code=429)),
+        )
+        provider_b = provider_b or FakeProvider("b", ["model-b"])
+        config = {
+            "providers": {"a": {"enabled": True}, "b": {"enabled": True}},
+            "routing": routing if routing is not None else {"fallback_chain": ["b/model-b"]},
+        }
+        return Client(config, providers={"a": provider_a, "b": provider_b})
+
+    def test_failover_to_second_provider(self):
+        client = self.make_client()
+        response = client.completion.create(
+            messages=[{"role": "user", "content": "hi"}],
+            model="a/model-a",
+        )
+        assert response.provider == "b"
+        assert response.model == "model-b"
+        assert response.fallback_used is True
+        assert response.fallback_attempts is not None
+        assert len(response.fallback_attempts) == 2
+        assert response.fallback_attempts[0]["provider"] == "a"
+        assert response.fallback_attempts[0]["succeeded"] is False
+        assert response.fallback_attempts[0]["error_category"] == "rate_limit"
+        assert response.fallback_attempts[1]["provider"] == "b"
+        assert response.fallback_attempts[1]["succeeded"] is True
+
+    def test_explicit_provider_failover(self):
+        client = self.make_client()
+        response = client.completion.create(
+            messages=[{"role": "user", "content": "hi"}],
+            provider="a",
+        )
+        assert response.provider == "b"
+        assert response.fallback_used is True
+
+    def test_no_failover_metadata_when_primary_succeeds(self):
+        provider_a = FakeProvider("a", ["model-a"])
+        client = self.make_client(provider_a=provider_a)
+        response = client.completion.create(
+            messages=[{"role": "user", "content": "hi"}],
+            model="a/model-a",
+        )
+        assert response.provider == "a"
+        assert response.fallback_used is False
+        assert response.fallback_attempts is None
+
+    def test_per_request_fallback_false_disables_failover(self):
+        client = self.make_client()
+        with pytest.raises(ProviderError, match="rate limited"):
+            client.completion.create(
+                messages=[{"role": "user", "content": "hi"}],
+                model="a/model-a",
+                fallback=False,
+            )
+
+    def test_non_retryable_error_no_failover(self):
+        provider_a = FakeProvider(
+            "a",
+            ["model-a"],
+            behavior=always_raise(ProviderError("bad request", status_code=400)),
+        )
+        provider_b = FakeProvider("b", ["model-b"])
+        client = self.make_client(provider_a=provider_a, provider_b=provider_b)
+        with pytest.raises(ProviderError, match="bad request"):
+            client.completion.create(
+                messages=[{"role": "user", "content": "hi"}],
+                model="a/model-a",
+            )
+        assert provider_b.calls == []
+
+    def test_no_fallback_config_keeps_current_behavior(self):
+        client = self.make_client(routing={})
+        with pytest.raises(ProviderError, match="rate limited"):
+            client.completion.create(
+                messages=[{"role": "user", "content": "hi"}],
+                model="a/model-a",
+            )
+
+    def test_fallback_kwarg_not_forwarded_to_provider(self):
+        provider_a = FakeProvider("a", ["model-a"])
+        client = self.make_client(provider_a=provider_a)
+        client.completion.create(
+            messages=[{"role": "user", "content": "hi"}],
+            model="a/model-a",
+            fallback=True,
+        )
+        assert provider_a.calls
+        assert "fallback" not in provider_a.calls[0]["kwargs"]
+
+    def test_auto_fallback_derivation(self):
+        provider_a = FakeProvider(
+            "a",
+            ["model-a"],
+            behavior=always_raise(ProviderError("down", status_code=503)),
+        )
+        client = self.make_client(routing={"auto_fallback": True}, provider_a=provider_a)
+        response = client.completion.create(
+            messages=[{"role": "user", "content": "hi"}],
+            model="a/model-a",
+        )
+        assert response.provider == "b"
+        assert response.fallback_used is True


### PR DESCRIPTION
## Summary

The README advertises "Automatic Fallbacks", but until now `routing.fallback_provider`/`fallback_model` were only used for *static* model selection — if the chosen provider then errored (rate limit, outage), the exception simply propagated. This PR adds true failure-driven failover: when a provider ultimately fails (after the existing tenacity HTTP retries in `BaseProvider._make_http_request`), the request automatically retries on the next provider/model in a configurable chain. Reliability/failover is the #1 table-stakes feature across every LLM gateway comparison.

### What's new

- **`justllms/reliability/`** — `classify_error()` maps exceptions to failover categories (`rate_limit` 429, `server_error` 5xx, `timeout`, `connection`, `auth` 401/403). Caller errors (400, 404, validation) never fail over — they'd fail everywhere.
- **`FallbackExecutor`** — builds the chain (primary first, then `fallback_chain` entries, deduped, truncated to `max_fallback_attempts`) and walks it, logging each failed attempt.
- **New `routing` config**:
  ```yaml
  routing:
    fallback_chain: ["anthropic/claude-sonnet-4-6", "google"]  # "provider/model" or bare "provider"
    auto_fallback: true            # derive chain from other configured providers when chain empty
    max_fallback_attempts: 3       # total attempts including the primary
    fallback_on: [rate_limit, server_error, timeout, connection, auth]
  ```
- **Per-request override**: `client.completion.create(..., fallback=False)` disables failover for one call; `fallback=True` forces it.
- **Response metadata**: when failover engages, the response carries `fallback_used=True` and `fallback_attempts` (provider, model, error, category, duration per attempt). `response.provider`/`model` and cost always reflect the provider that actually served the request.

### Scope
Applies to non-streaming, non-tool requests (explicit-provider requests included — the chain applies after the requested primary). Streaming/tool calls keep current behavior; HTTP-level retries still apply everywhere. Documented in README.

## Testing
- 43 new tests in `tests/test_fallback.py`: error classification matrix, chain building (resolution, skips, dedupe, truncation, auto-derivation), executor semantics (success-after-429, non-retryable immediate re-raise, exhaustion raises last error, `fallback_on` filtering), and client end-to-end with stub providers
- `ruff`, `black --check`, `mypy` (strict) all clean

https://claude.ai/code/session_01DC8Ax6EFiFnCFsGEHhW3MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC8Ax6EFiFnCFsGEHhW3MH)_