### PR TITLE
feat: response caching with memory and disk backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ venv/
 *.csv
 *.pdf
 test_*.py
+!tests/test_*.py
 demo_*.py
 debug_*.py
 simple_*.py

--- a/README.md
+++ b/README.md
@@ -253,6 +253,59 @@ except BudgetExceededError as e:
 
 Note: budget checks are *pre-flight* — each request is checked against usage accumulated so far, so the request that crosses a limit completes normally and the next one is blocked. Limits are cumulative for the client's lifetime (or since `reset_usage()`).
 
+### Response Caching
+Cache identical completion requests to cut latency and cost. Responses are cached on an exact match of provider, model, messages, and generation parameters (temperature, max_tokens, etc.). Caching is opt-in via config:
+
+```python
+client = JustLLM({
+    "providers": {"openai": {"api_key": "your-key"}},
+    "cache": {
+        "enabled": True,
+        "backend": "memory",   # "memory" (default) or "disk"
+        "ttl": 3600,           # seconds; None = entries never expire
+        "max_size": 1000       # memory backend: LRU-evicted beyond this
+    }
+})
+
+response = client.completion.create(
+    messages=[{"role": "user", "content": "Hello"}],
+    model="gpt-4o-mini"
+)
+
+# Identical request -> served from cache, no API call
+cached_response = client.completion.create(
+    messages=[{"role": "user", "content": "Hello"}],
+    model="gpt-4o-mini"
+)
+assert cached_response.cached  # True; usage and estimated cost preserved
+```
+
+Or in YAML config:
+
+```yaml
+cache:
+  enabled: true
+  backend: disk                # persists across restarts
+  path: ~/.justllms/cache.db   # optional; this is the default
+  ttl: 86400
+```
+
+Per-request controls:
+
+```python
+# Bypass the cache for one call (no read, no write)
+client.completion.create(messages=msgs, cache=False)
+
+# Override the TTL for the stored entry (seconds)
+client.completion.create(messages=msgs, cache_ttl=60)
+```
+
+Backends:
+- **memory**: in-process LRU cache (`max_size` entries), thread-safe, cleared when the process exits.
+- **disk**: SQLite database (default `~/.justllms/cache.db`), survives restarts, shareable across processes on the same machine.
+
+Notes: streaming requests and tool-calling requests are never cached (a cache hit also skips failover and consumes no budget). Passing `cache=True` when caching is not enabled in config raises a `ConfigurationError`.
+
 ## Side-by-Side Model Comparison
 
 Compare multiple LLM providers and models simultaneously with our interactive SXS (Side-by-Side) comparison tool. Perfect for evaluating model performance, testing prompts, and making informed decisions about which models to use.

--- a/justllms/cache/__init__.py
+++ b/justllms/cache/__init__.py
@@ -1,0 +1,25 @@
+"""Response caching for justllms.
+
+Provides exact-match caching of non-streaming, non-tool completion
+responses, keyed on provider, model, messages, and generation parameters.
+"""
+
+from justllms.cache.base import BaseCacheBackend
+from justllms.cache.disk import DiskCache
+from justllms.cache.manager import (
+    ResponseCache,
+    _response_from_cache_dict,
+    _response_to_cache_dict,
+    make_cache_key,
+)
+from justllms.cache.memory import InMemoryCache
+
+__all__ = [
+    "BaseCacheBackend",
+    "DiskCache",
+    "InMemoryCache",
+    "ResponseCache",
+    "make_cache_key",
+    "_response_from_cache_dict",
+    "_response_to_cache_dict",
+]

--- a/justllms/cache/base.py
+++ b/justllms/cache/base.py
@@ -1,0 +1,50 @@
+"""Abstract base class for response cache backends."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class BaseCacheBackend(ABC):
+    """Abstract interface for cache storage backends.
+
+    Implementations store JSON-serializable response dictionaries keyed by
+    opaque string keys, with optional per-entry time-to-live expiry.
+    """
+
+    @abstractmethod
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a cached value by key.
+
+        Args:
+            key: Cache key to look up.
+
+        Returns:
+            The cached dictionary, or None if the key is missing or expired.
+        """
+
+    @abstractmethod
+    def set(self, key: str, value: Dict[str, Any], ttl: Optional[float] = None) -> None:
+        """Store a value under the given key.
+
+        Args:
+            key: Cache key to store under.
+            value: JSON-serializable dictionary to cache.
+            ttl: Optional time-to-live in seconds. None means no expiry.
+        """
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Remove a single entry from the cache.
+
+        Args:
+            key: Cache key to remove. Missing keys are ignored.
+        """
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all entries from the cache."""
+
+    @property
+    def stats(self) -> Dict[str, Any]:
+        """Return backend statistics (hits, misses, size) when available."""
+        return {}

--- a/justllms/cache/disk.py
+++ b/justllms/cache/disk.py
@@ -1,0 +1,116 @@
+"""SQLite-backed persistent cache backend."""
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+from justllms.cache.base import BaseCacheBackend
+
+DEFAULT_CACHE_PATH = "~/.justllms/cache.db"
+
+# Purge expired rows on every Nth write to keep the file from growing.
+_PURGE_EVERY_N_SETS = 100
+
+
+class DiskCache(BaseCacheBackend):
+    """Persistent cache backed by a SQLite database file.
+
+    Survives process restarts. Thread-safe via a single shared connection
+    guarded by a lock. Expired rows are purged lazily on reads and
+    periodically on writes.
+
+    Args:
+        path: Path to the SQLite database file. Defaults to
+            ``~/.justllms/cache.db``. Parent directories are created.
+    """
+
+    def __init__(self, path: Optional[Union[str, Path]] = None) -> None:
+        resolved = Path(path if path is not None else DEFAULT_CACHE_PATH).expanduser()
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        self.path = resolved
+        self._lock = threading.Lock()
+        self._set_count = 0
+        self._hits = 0
+        self._misses = 0
+        self._conn = sqlite3.connect(str(resolved), check_same_thread=False)
+        with self._lock:
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS response_cache (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL,
+                    expires_at REAL,
+                    created_at REAL NOT NULL
+                )
+                """)
+            self._conn.commit()
+
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a cached value, deleting it if expired."""
+        now = time.time()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT value, expires_at FROM response_cache WHERE key = ?", (key,)
+            ).fetchone()
+            if row is None:
+                self._misses += 1
+                return None
+            value_text, expires_at = row
+            if expires_at is not None and now >= expires_at:
+                self._conn.execute("DELETE FROM response_cache WHERE key = ?", (key,))
+                self._conn.commit()
+                self._misses += 1
+                return None
+            self._hits += 1
+        loaded = json.loads(value_text)
+        return loaded if isinstance(loaded, dict) else None
+
+    def set(self, key: str, value: Dict[str, Any], ttl: Optional[float] = None) -> None:
+        """Store a value, occasionally purging expired rows."""
+        now = time.time()
+        expires_at = now + ttl if ttl is not None else None
+        value_text = json.dumps(value, default=str)
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO response_cache (key, value, expires_at, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (key, value_text, expires_at, now),
+            )
+            self._set_count += 1
+            if self._set_count % _PURGE_EVERY_N_SETS == 0:
+                self._conn.execute(
+                    "DELETE FROM response_cache WHERE expires_at IS NOT NULL AND expires_at <= ?",
+                    (now,),
+                )
+            self._conn.commit()
+
+    def delete(self, key: str) -> None:
+        """Remove a single entry if present."""
+        with self._lock:
+            self._conn.execute("DELETE FROM response_cache WHERE key = ?", (key,))
+            self._conn.commit()
+
+    def clear(self) -> None:
+        """Remove all entries."""
+        with self._lock:
+            self._conn.execute("DELETE FROM response_cache")
+            self._conn.commit()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        with self._lock:
+            self._conn.close()
+
+    @property
+    def stats(self) -> Dict[str, Any]:
+        """Return hit/miss counters and current row count."""
+        with self._lock:
+            row = self._conn.execute("SELECT COUNT(*) FROM response_cache").fetchone()
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "size": int(row[0]) if row else 0,
+                "path": str(self.path),
+            }

--- a/justllms/cache/manager.py
+++ b/justllms/cache/manager.py
@@ -1,0 +1,151 @@
+"""Response cache manager: key generation, serialization, and backend wrapper."""
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from justllms.cache.base import BaseCacheBackend
+from justllms.core.models import Choice, Message, Usage
+
+if TYPE_CHECKING:
+    from justllms.core.completion import CompletionResponse
+
+# Keys that control caching/transport behavior and must never affect cache keys.
+_KEY_EXCLUDED_PARAMS = frozenset(
+    {"cache", "cache_ttl", "stream", "tools", "tool_choice", "execute_tools", "timeout"}
+)
+
+
+def make_cache_key(
+    provider: str,
+    model: str,
+    messages: List[Message],
+    params: Dict[str, Any],
+) -> str:
+    """Build a deterministic cache key for a completion request.
+
+    Canonicalizes provider, model, message contents, and the generation
+    parameters that affect output into sorted compact JSON, then hashes
+    with SHA-256.
+
+    Args:
+        provider: Provider name handling the request.
+        model: Model identifier.
+        messages: Conversation messages.
+        params: Generation parameters (cache-control and transport keys
+            are stripped; None values are ignored).
+
+    Returns:
+        Hex-encoded SHA-256 digest string.
+    """
+    message_dicts = [msg.model_dump(mode="json", exclude_none=True) for msg in messages]
+    effective_params = {
+        key: value
+        for key, value in params.items()
+        if key not in _KEY_EXCLUDED_PARAMS and value is not None
+    }
+    payload = {
+        "provider": provider,
+        "model": model,
+        "messages": message_dicts,
+        "params": effective_params,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _response_to_cache_dict(response: "CompletionResponse") -> Dict[str, Any]:
+    """Serialize a CompletionResponse to a JSON-friendly dictionary."""
+    return {
+        "id": response.id,
+        "model": response.model,
+        "choices": [choice.model_dump(mode="json") for choice in response.choices],
+        "usage": response.usage.model_dump(mode="json") if response.usage else None,
+        "created": response.created,
+        "system_fingerprint": response.system_fingerprint,
+        "provider": response.provider,
+        "raw_response": response.raw_response,
+    }
+
+
+def _response_from_cache_dict(data: Dict[str, Any]) -> "CompletionResponse":
+    """Reconstruct a CompletionResponse (with cached=True) from a stored dict."""
+    from justllms.core.completion import CompletionResponse
+
+    choices = [Choice(**choice_data) for choice_data in data.get("choices", [])]
+    usage_data = data.get("usage")
+    usage = Usage(**usage_data) if usage_data else None
+    # Copy to avoid mutating dicts shared with the cache backend, and drop
+    # any key that would collide with the explicit ``cached`` argument.
+    raw_response = dict(data.get("raw_response") or {})
+    raw_response.pop("cached", None)
+
+    response = CompletionResponse(
+        id=data.get("id", ""),
+        model=data.get("model", ""),
+        choices=choices,
+        usage=usage,
+        created=data.get("created"),
+        system_fingerprint=data.get("system_fingerprint"),
+        provider=data.get("provider"),
+        cached=True,
+        **raw_response,
+    )
+    return response
+
+
+class ResponseCache:
+    """High-level response cache combining a backend with key generation.
+
+    Args:
+        backend: Storage backend implementing BaseCacheBackend.
+        default_ttl: Default time-to-live in seconds for stored entries.
+            None disables expiry.
+    """
+
+    def __init__(self, backend: BaseCacheBackend, default_ttl: Optional[float] = 3600.0) -> None:
+        self.backend = backend
+        self.default_ttl = default_ttl
+
+    def get(
+        self,
+        provider: str,
+        model: str,
+        messages: List[Message],
+        params: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Look up a cached response dict for the given request, if any."""
+        key = make_cache_key(provider, model, messages, params)
+        return self.backend.get(key)
+
+    def set(
+        self,
+        provider: str,
+        model: str,
+        messages: List[Message],
+        params: Dict[str, Any],
+        value: Dict[str, Any],
+        ttl: Optional[float] = None,
+    ) -> None:
+        """Store a serialized response dict for the given request.
+
+        Args:
+            provider: Provider name handling the request.
+            model: Model identifier.
+            messages: Conversation messages.
+            params: Generation parameters used for the request.
+            value: Serialized response dictionary to store.
+            ttl: Per-entry TTL override in seconds; falls back to default_ttl.
+        """
+        key = make_cache_key(provider, model, messages, params)
+        effective_ttl = ttl if ttl is not None else self.default_ttl
+        self.backend.set(key, value, ttl=effective_ttl)
+
+    def clear(self) -> None:
+        """Remove all cached responses."""
+        self.backend.clear()
+
+    @property
+    def stats(self) -> Dict[str, Any]:
+        """Return backend statistics."""
+        return self.backend.stats

--- a/justllms/cache/memory.py
+++ b/justllms/cache/memory.py
@@ -1,0 +1,81 @@
+"""Thread-safe in-memory LRU cache backend."""
+
+import threading
+import time
+from collections import OrderedDict
+from typing import Any, Dict, Optional, Tuple
+
+from justllms.cache.base import BaseCacheBackend
+
+
+class InMemoryCache(BaseCacheBackend):
+    """In-process LRU cache with optional per-entry TTL.
+
+    Entries are evicted least-recently-used first once ``max_size`` is
+    reached. Expired entries are treated as misses and purged lazily.
+
+    Args:
+        max_size: Maximum number of entries to keep (default 1000).
+    """
+
+    def __init__(self, max_size: int = 1000) -> None:
+        if max_size <= 0:
+            raise ValueError("max_size must be a positive integer")
+        self.max_size = max_size
+        # key -> (value, expires_at). expires_at is monotonic time or None.
+        self._data: OrderedDict[str, Tuple[Dict[str, Any], Optional[float]]] = OrderedDict()
+        self._lock = threading.Lock()
+        self._hits = 0
+        self._misses = 0
+
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a cached value, honoring TTL and updating LRU order."""
+        with self._lock:
+            entry = self._data.get(key)
+            if entry is None:
+                self._misses += 1
+                return None
+            value, expires_at = entry
+            if expires_at is not None and time.monotonic() >= expires_at:
+                # Expired: purge lazily and report a miss.
+                del self._data[key]
+                self._misses += 1
+                return None
+            self._data.move_to_end(key)
+            self._hits += 1
+            return value
+
+    def set(self, key: str, value: Dict[str, Any], ttl: Optional[float] = None) -> None:
+        """Store a value, evicting least-recently-used entries if full."""
+        expires_at = time.monotonic() + ttl if ttl is not None else None
+        with self._lock:
+            if key in self._data:
+                del self._data[key]
+            self._data[key] = (value, expires_at)
+            while len(self._data) > self.max_size:
+                self._data.popitem(last=False)
+
+    def delete(self, key: str) -> None:
+        """Remove a single entry if present."""
+        with self._lock:
+            self._data.pop(key, None)
+
+    def clear(self) -> None:
+        """Remove all entries."""
+        with self._lock:
+            self._data.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+    @property
+    def stats(self) -> Dict[str, Any]:
+        """Return hit/miss counters and current size."""
+        with self._lock:
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "size": len(self._data),
+                "max_size": self.max_size,
+            }

--- a/justllms/config/__init__.py
+++ b/justllms/config/__init__.py
@@ -1,6 +1,7 @@
-from justllms.config.config import Config, load_config
+from justllms.config.config import CacheConfig, Config, load_config
 
 __all__ = [
+    "CacheConfig",
     "Config",
     "load_config",
 ]

--- a/justllms/config/config.py
+++ b/justllms/config/config.py
@@ -56,6 +56,27 @@ class RoutingConfig(BaseModel):
     execute_tools_by_default: bool = False
 
 
+class CacheConfig(BaseModel):
+    """Configuration for response caching."""
+
+    model_config = ConfigDict(extra="allow")
+
+    enabled: bool = False
+    """Whether response caching is enabled."""
+
+    backend: str = "memory"
+    """Cache backend to use: "memory" or "disk"."""
+
+    ttl: Optional[float] = 3600.0
+    """Default time-to-live in seconds for cached entries. None = no expiry."""
+
+    max_size: int = 1000
+    """Maximum number of entries (memory backend only)."""
+
+    path: Optional[str] = None
+    """Database file path for the disk backend (default ~/.justllms/cache.db)."""
+
+
 class Config(BaseModel):
     """Configuration class for multi-provider LLM client."""
 
@@ -64,6 +85,7 @@ class Config(BaseModel):
     providers: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     routing: RoutingConfig = Field(default_factory=RoutingConfig)
     budget: Optional[BudgetConfig] = None
+    cache: CacheConfig = Field(default_factory=CacheConfig)
 
     @classmethod
     def from_file(cls, path: Union[str, Path]) -> "Config":

--- a/justllms/core/client.py
+++ b/justllms/core/client.py
@@ -1,6 +1,14 @@
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
+from justllms.cache import (
+    BaseCacheBackend,
+    DiskCache,
+    InMemoryCache,
+    ResponseCache,
+    _response_from_cache_dict,
+    _response_to_cache_dict,
+)
 from justllms.config import Config
 from justllms.core.base import BaseProvider, BaseResponse
 from justllms.core.completion import Completion, CompletionResponse
@@ -45,6 +53,8 @@ class Client:
 
         self.tool_registry = ToolRegistry()
 
+        self.cache: Optional[ResponseCache] = self._initialize_cache()
+
         self.completion = Completion(self)
 
         if providers is None:
@@ -76,6 +86,35 @@ class Client:
             from justllms.config import load_config
 
             return load_config(use_defaults=True, use_env=True)
+
+    def _initialize_cache(self) -> Optional[ResponseCache]:
+        """Build the response cache from configuration.
+
+        Returns:
+            ResponseCache instance when caching is enabled in config,
+            None otherwise.
+
+        Raises:
+            ConfigurationError: If an unknown cache backend is configured.
+        """
+        cache_config = getattr(self.config, "cache", None)
+        if cache_config is None or not cache_config.enabled:
+            return None
+
+        backend: BaseCacheBackend
+        if cache_config.backend == "memory":
+            backend = InMemoryCache(max_size=cache_config.max_size)
+        elif cache_config.backend == "disk":
+            backend = DiskCache(path=cache_config.path)
+        else:
+            raise ConfigurationError(
+                f"Unknown cache backend '{cache_config.backend}'. "
+                "Valid backends are 'memory' and 'disk'.",
+                config_key="cache.backend",
+                config_value=cache_config.backend,
+            )
+
+        return ResponseCache(backend=backend, default_ttl=cache_config.ttl)
 
     def _initialize_providers(self) -> None:
         """Initialize providers based on configuration settings.
@@ -354,6 +393,16 @@ class Client:
         # Per-request failover override; popped so it never reaches provider payloads.
         fallback_override: Optional[bool] = kwargs.pop("fallback", None)
 
+        # Pop cache-control kwargs first so they never reach provider payloads.
+        cache_flag = kwargs.pop("cache", None)
+        cache_ttl = kwargs.pop("cache_ttl", None)
+        if cache_flag is True and self.cache is None:
+            raise ConfigurationError(
+                "cache=True was passed but response caching is not configured. "
+                "Enable it via config, e.g. {'cache': {'enabled': True}}.",
+                config_key="cache.enabled",
+            )
+
         # Check if tools are provided
         tools = kwargs.pop("tools", None)
         if tools and stream:
@@ -452,10 +501,12 @@ class Client:
             else:
                 # Non-streaming with specified provider; explicit provider is the
                 # primary and the configured fallback chain still applies after it.
-                return self._complete_with_fallback(
-                    messages=messages,
+                return self._complete_non_streaming(
                     provider_name=provider,
-                    selected_model=selected_model,
+                    model=selected_model,
+                    messages=messages,
+                    use_cache=cache_flag is not False,
+                    cache_ttl=cache_ttl,
                     fallback_override=fallback_override,
                     **kwargs,
                 )
@@ -480,10 +531,73 @@ class Client:
                 messages=messages, model=model, providers=self.providers, **kwargs
             )
 
-            return self._complete_with_fallback(
-                messages=messages,
+            return self._complete_non_streaming(
                 provider_name=provider_name,
-                selected_model=selected_model,
+                model=selected_model,
+                messages=messages,
+                use_cache=cache_flag is not False,
+                cache_ttl=cache_ttl,
                 fallback_override=fallback_override,
                 **kwargs,
             )
+
+    def _complete_non_streaming(
+        self,
+        provider_name: str,
+        model: str,
+        messages: List[Message],
+        use_cache: bool = True,
+        cache_ttl: Optional[float] = None,
+        fallback_override: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> CompletionResponse:
+        """Execute a non-streaming completion with caching and failover.
+
+        The cache is consulted before any provider call (a hit skips failover
+        entirely and consumes no budget); on a miss the request runs through
+        the failure-driven fallback chain and the successful response is
+        cached under the originally requested provider/model key.
+
+        Args:
+            provider_name: Resolved provider name.
+            model: Resolved model identifier.
+            messages: Conversation messages.
+            use_cache: Whether the cache may be consulted/updated for this
+                call. Effective only when a cache is configured.
+            cache_ttl: Optional per-request TTL override in seconds.
+            fallback_override: Per-request failover override passed through
+                to the fallback executor.
+            **kwargs: Provider generation parameters.
+
+        Returns:
+            CompletionResponse from the cache (cached=True) or a provider.
+        """
+        cache_enabled = use_cache and self.cache is not None
+
+        if cache_enabled and self.cache is not None:
+            cached_data = self.cache.get(provider_name, model, messages, kwargs)
+            if cached_data is not None:
+                logger.debug(
+                    "Response cache hit for provider '%s', model '%s'", provider_name, model
+                )
+                return _response_from_cache_dict(cached_data)
+
+        completion_response = self._complete_with_fallback(
+            messages=messages,
+            provider_name=provider_name,
+            selected_model=model,
+            fallback_override=fallback_override,
+            **kwargs,
+        )
+
+        if cache_enabled and self.cache is not None:
+            self.cache.set(
+                provider_name,
+                model,
+                messages,
+                kwargs,
+                _response_to_cache_dict(completion_response),
+                ttl=cache_ttl,
+            )
+
+        return completion_response

--- a/justllms/core/completion.py
+++ b/justllms/core/completion.py
@@ -21,6 +21,7 @@ class CompletionResponse(BaseResponse):
         created: Optional[int] = None,
         system_fingerprint: Optional[str] = None,
         provider: Optional[str] = None,
+        cached: bool = False,
         **kwargs: Any,
     ):
         super().__init__(
@@ -33,6 +34,7 @@ class CompletionResponse(BaseResponse):
             **kwargs,
         )
         self.provider = provider
+        self.cached = cached
         self.tool_execution_history: Optional[List[Any]] = None
         self.tools_used: Optional[List[str]] = None
         self.tool_execution_cost: Optional[float] = None
@@ -70,6 +72,7 @@ class CompletionResponse(BaseResponse):
             "provider": self.provider,
             "fallback_used": self.fallback_used,
             "fallback_attempts": self.fallback_attempts,
+            "cached": self.cached,
         }
 
     @property
@@ -111,6 +114,8 @@ class Completion:
         user: Optional[str] = None,
         timeout: Optional[float] = None,
         fallback: Optional[bool] = None,
+        cache: Optional[bool] = None,
+        cache_ttl: Optional[float] = None,
         **kwargs: Any,
     ) -> CompletionResponse: ...
 
@@ -138,6 +143,8 @@ class Completion:
         user: Optional[str] = None,
         timeout: Optional[float] = None,
         fallback: Optional[bool] = None,
+        cache: Optional[bool] = None,
+        cache_ttl: Optional[float] = None,
         **kwargs: Any,
     ) -> "SyncStreamResponse": ...
 
@@ -164,6 +171,8 @@ class Completion:
         user: Optional[str] = None,
         timeout: Optional[float] = None,
         fallback: Optional[bool] = None,
+        cache: Optional[bool] = None,
+        cache_ttl: Optional[float] = None,
         **kwargs: Any,
     ) -> "Union[CompletionResponse, SyncStreamResponse]":
         """Create a completion with automatic fallbacks.
@@ -203,6 +212,12 @@ class Completion:
                     (failover is active when fallback_chain is non-empty or
                     auto_fallback is true). Applies to non-streaming, non-tool
                     requests only.
+
+            Caching (requires config ``cache.enabled: true``):
+                cache: Set to False to bypass the response cache for this call
+                       (no read, no write). Set to True to assert caching; raises
+                       ConfigurationError if caching is not configured.
+                cache_ttl: Per-request TTL override in seconds for the stored entry.
 
         Returns:
             CompletionResponse: The model's response.
@@ -254,6 +269,8 @@ class Completion:
             "user": user,
             "timeout": timeout,
             "fallback": fallback,
+            "cache": cache,
+            "cache_ttl": cache_ttl,
             **kwargs,
         }
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,424 @@
+"""Tests for the response caching feature."""
+
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from justllms.cache import DiskCache, InMemoryCache, make_cache_key
+from justllms.core.base import BaseProvider, BaseResponse
+from justllms.core.client import Client
+from justllms.core.models import (
+    Choice,
+    Message,
+    ModelInfo,
+    ProviderConfig,
+    Role,
+    Usage,
+)
+from justllms.exceptions import ConfigurationError
+
+
+def _msg(content: str, role: Role = Role.USER) -> Message:
+    return Message(role=role, content=content)
+
+
+# ---------------------------------------------------------------------------
+# Cache key generation
+# ---------------------------------------------------------------------------
+
+
+class TestMakeCacheKey:
+    def test_deterministic(self):
+        messages = [_msg("hello")]
+        params = {"temperature": 0.5, "max_tokens": 10}
+        key1 = make_cache_key("openai", "gpt-4", messages, params)
+        key2 = make_cache_key("openai", "gpt-4", [_msg("hello")], dict(params))
+        assert key1 == key2
+        assert len(key1) == 64  # sha256 hex digest
+
+    def test_param_order_independent(self):
+        messages = [_msg("hello")]
+        key1 = make_cache_key("p", "m", messages, {"temperature": 0.5, "max_tokens": 10})
+        key2 = make_cache_key("p", "m", messages, {"max_tokens": 10, "temperature": 0.5})
+        assert key1 == key2
+
+    def test_sensitive_to_temperature(self):
+        messages = [_msg("hello")]
+        key1 = make_cache_key("p", "m", messages, {"temperature": 0.5})
+        key2 = make_cache_key("p", "m", messages, {"temperature": 0.7})
+        assert key1 != key2
+
+    def test_sensitive_to_model_and_provider(self):
+        messages = [_msg("hello")]
+        params: Dict[str, Any] = {}
+        assert make_cache_key("p", "m1", messages, params) != make_cache_key(
+            "p", "m2", messages, params
+        )
+        assert make_cache_key("p1", "m", messages, params) != make_cache_key(
+            "p2", "m", messages, params
+        )
+
+    def test_sensitive_to_messages(self):
+        key1 = make_cache_key("p", "m", [_msg("hello")], {})
+        key2 = make_cache_key("p", "m", [_msg("goodbye")], {})
+        key3 = make_cache_key("p", "m", [_msg("hello", role=Role.SYSTEM)], {})
+        assert len({key1, key2, key3}) == 3
+
+    def test_cache_control_keys_ignored(self):
+        messages = [_msg("hello")]
+        key1 = make_cache_key("p", "m", messages, {"temperature": 0.5})
+        key2 = make_cache_key(
+            "p",
+            "m",
+            messages,
+            {"temperature": 0.5, "cache": True, "cache_ttl": 5.0, "timeout": 30.0},
+        )
+        assert key1 == key2
+
+    def test_none_params_ignored(self):
+        messages = [_msg("hello")]
+        key1 = make_cache_key("p", "m", messages, {"temperature": 0.5})
+        key2 = make_cache_key("p", "m", messages, {"temperature": 0.5, "seed": None})
+        assert key1 == key2
+
+
+# ---------------------------------------------------------------------------
+# InMemoryCache
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryCache:
+    def test_set_get_delete_clear(self):
+        cache = InMemoryCache(max_size=10)
+        assert cache.get("k") is None
+        cache.set("k", {"v": 1})
+        assert cache.get("k") == {"v": 1}
+        cache.delete("k")
+        assert cache.get("k") is None
+        cache.set("a", {"v": 1})
+        cache.set("b", {"v": 2})
+        cache.clear()
+        assert cache.get("a") is None
+        assert cache.get("b") is None
+
+    def test_ttl_expiry(self):
+        cache = InMemoryCache()
+        cache.set("k", {"v": 1}, ttl=0.05)
+        assert cache.get("k") == {"v": 1}
+        time.sleep(0.08)
+        assert cache.get("k") is None
+        assert len(cache) == 0  # purged lazily
+
+    def test_no_ttl_means_no_expiry(self):
+        cache = InMemoryCache()
+        cache.set("k", {"v": 1}, ttl=None)
+        time.sleep(0.02)
+        assert cache.get("k") == {"v": 1}
+
+    def test_lru_eviction(self):
+        cache = InMemoryCache(max_size=3)
+        cache.set("a", {"v": 1})
+        cache.set("b", {"v": 2})
+        cache.set("c", {"v": 3})
+        # Touch "a" so "b" becomes least recently used.
+        assert cache.get("a") is not None
+        cache.set("d", {"v": 4})
+        assert cache.get("b") is None
+        assert cache.get("a") is not None
+        assert cache.get("c") is not None
+        assert cache.get("d") is not None
+        assert len(cache) == 3
+
+    def test_invalid_max_size(self):
+        with pytest.raises(ValueError):
+            InMemoryCache(max_size=0)
+
+    def test_stats(self):
+        cache = InMemoryCache()
+        cache.set("k", {"v": 1})
+        cache.get("k")
+        cache.get("missing")
+        stats = cache.stats
+        assert stats["hits"] == 1
+        assert stats["misses"] == 1
+        assert stats["size"] == 1
+
+    def test_thread_safety_smoke(self):
+        cache = InMemoryCache(max_size=50)
+        errors: List[Exception] = []
+
+        def worker(worker_id: int) -> None:
+            try:
+                for i in range(200):
+                    key = f"k-{worker_id}-{i % 10}"
+                    cache.set(key, {"v": i})
+                    cache.get(key)
+                    if i % 7 == 0:
+                        cache.delete(key)
+            except Exception as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(n,)) for n in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors
+        assert len(cache) <= 50
+
+
+# ---------------------------------------------------------------------------
+# DiskCache
+# ---------------------------------------------------------------------------
+
+
+class TestDiskCache:
+    def test_roundtrip(self, tmp_path):
+        cache = DiskCache(path=tmp_path / "cache.db")
+        assert cache.get("k") is None
+        cache.set("k", {"v": [1, 2], "nested": {"a": True}})
+        assert cache.get("k") == {"v": [1, 2], "nested": {"a": True}}
+        cache.delete("k")
+        assert cache.get("k") is None
+        cache.set("a", {"v": 1})
+        cache.clear()
+        assert cache.get("a") is None
+        cache.close()
+
+    def test_ttl_expiry(self, tmp_path):
+        cache = DiskCache(path=tmp_path / "cache.db")
+        cache.set("k", {"v": 1}, ttl=0.05)
+        assert cache.get("k") == {"v": 1}
+        time.sleep(0.08)
+        assert cache.get("k") is None
+        cache.close()
+
+    def test_persistence_across_instances(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        cache1 = DiskCache(path=db_path)
+        cache1.set("k", {"v": "persisted"})
+        cache1.close()
+
+        cache2 = DiskCache(path=db_path)
+        assert cache2.get("k") == {"v": "persisted"}
+        cache2.close()
+
+    def test_stats(self, tmp_path):
+        cache = DiskCache(path=tmp_path / "cache.db")
+        cache.set("k", {"v": 1})
+        cache.get("k")
+        cache.get("missing")
+        stats = cache.stats
+        assert stats["hits"] == 1
+        assert stats["misses"] == 1
+        assert stats["size"] == 1
+        cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Client integration
+# ---------------------------------------------------------------------------
+
+
+class FakeProvider(BaseProvider):
+    """Minimal provider returning canned responses and counting calls."""
+
+    requires_api_key = False
+
+    def __init__(self) -> None:
+        super().__init__(ProviderConfig(name="fake"))
+        self.call_count = 0
+        self.last_kwargs: Dict[str, Any] = {}
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    def get_available_models(self) -> Dict[str, ModelInfo]:
+        return {
+            "fake-model": ModelInfo(
+                name="fake-model",
+                provider="fake",
+                cost_per_1k_prompt_tokens=0.001,
+                cost_per_1k_completion_tokens=0.002,
+            )
+        }
+
+    def complete(
+        self,
+        messages: List[Message],
+        model: str,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
+    ) -> BaseResponse:
+        self.call_count += 1
+        self.last_kwargs = dict(kwargs)
+        message = Message(role=Role.ASSISTANT, content=f"response-{self.call_count}")
+        choice = Choice(index=0, message=message, finish_reason="stop")
+        usage = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        return BaseResponse(
+            id=f"resp-{self.call_count}",
+            model=model,
+            choices=[choice],
+            usage=usage,
+            created=1700000000,
+        )
+
+
+def _make_client(cache_config: Optional[Dict[str, Any]] = None) -> "tuple[Client, FakeProvider]":
+    provider = FakeProvider()
+    config: Dict[str, Any] = {"providers": {}}
+    if cache_config is not None:
+        config["cache"] = cache_config
+    client = Client(config=config, providers={"fake": provider})
+    return client, provider
+
+
+class TestClientCaching:
+    def test_cache_hit_on_identical_request(self):
+        client, provider = _make_client({"enabled": True})
+        messages = [{"role": "user", "content": "hello"}]
+
+        first = client.completion.create(messages=messages, provider="fake")
+        second = client.completion.create(messages=messages, provider="fake")
+
+        assert provider.call_count == 1
+        assert first.cached is False
+        assert second.cached is True
+        assert second.content == first.content
+        assert second.provider == "fake"
+        assert second.model == first.model
+        assert second.usage is not None and first.usage is not None
+        assert second.usage.total_tokens == first.usage.total_tokens
+        # Cost is estimated before caching, so it round-trips too.
+        assert first.usage.estimated_cost == pytest.approx(0.001 * 10 / 1000 + 0.002 * 5 / 1000)
+        assert second.usage.estimated_cost == first.usage.estimated_cost
+
+    def test_cache_hit_via_routed_path(self):
+        client, provider = _make_client({"enabled": True})
+        messages = [{"role": "user", "content": "routed"}]
+
+        first = client.completion.create(messages=messages)
+        second = client.completion.create(messages=messages)
+
+        assert provider.call_count == 1
+        assert second.cached is True
+        assert second.content == first.content
+
+    def test_different_prompt_misses(self):
+        client, provider = _make_client({"enabled": True})
+        client.completion.create(messages=[{"role": "user", "content": "one"}], provider="fake")
+        client.completion.create(messages=[{"role": "user", "content": "two"}], provider="fake")
+        assert provider.call_count == 2
+
+    def test_different_params_miss(self):
+        client, provider = _make_client({"enabled": True})
+        messages = [{"role": "user", "content": "hello"}]
+        client.completion.create(messages=messages, provider="fake", temperature=0.1)
+        client.completion.create(messages=messages, provider="fake", temperature=0.9)
+        assert provider.call_count == 2
+
+    def test_cache_false_bypasses(self):
+        client, provider = _make_client({"enabled": True})
+        messages = [{"role": "user", "content": "hello"}]
+
+        client.completion.create(messages=messages, provider="fake", cache=False)
+        client.completion.create(messages=messages, provider="fake", cache=False)
+        assert provider.call_count == 2
+
+        # Bypassed calls also did not write to the cache.
+        response = client.completion.create(messages=messages, provider="fake")
+        assert provider.call_count == 3
+        assert response.cached is False
+
+    def test_cache_kwargs_not_forwarded_to_provider(self):
+        client, provider = _make_client({"enabled": True})
+        client.completion.create(
+            messages=[{"role": "user", "content": "hello"}],
+            provider="fake",
+            cache=True,
+            cache_ttl=60.0,
+            temperature=0.2,
+        )
+        assert "cache" not in provider.last_kwargs
+        assert "cache_ttl" not in provider.last_kwargs
+        assert provider.last_kwargs.get("temperature") == 0.2
+
+    def test_per_request_cache_ttl(self):
+        client, provider = _make_client({"enabled": True, "ttl": None})
+        messages = [{"role": "user", "content": "hello"}]
+
+        client.completion.create(messages=messages, provider="fake", cache_ttl=0.05)
+        time.sleep(0.08)
+        client.completion.create(messages=messages, provider="fake")
+        assert provider.call_count == 2
+
+    def test_disabled_by_default(self):
+        client, provider = _make_client()
+        assert client.cache is None
+        messages = [{"role": "user", "content": "hello"}]
+        client.completion.create(messages=messages, provider="fake")
+        client.completion.create(messages=messages, provider="fake")
+        assert provider.call_count == 2
+
+    def test_cache_true_without_config_raises(self):
+        client, _ = _make_client()
+        with pytest.raises(ConfigurationError, match="not configured"):
+            client.completion.create(
+                messages=[{"role": "user", "content": "hello"}],
+                provider="fake",
+                cache=True,
+            )
+
+    def test_unknown_backend_raises(self):
+        with pytest.raises(ConfigurationError, match="Unknown cache backend"):
+            _make_client({"enabled": True, "backend": "redis"})
+
+    def test_disk_backend_via_config(self, tmp_path):
+        db_path = str(tmp_path / "cache.db")
+        client, provider = _make_client({"enabled": True, "backend": "disk", "path": db_path})
+        messages = [{"role": "user", "content": "hello"}]
+
+        first = client.completion.create(messages=messages, provider="fake")
+        second = client.completion.create(messages=messages, provider="fake")
+        assert provider.call_count == 1
+        assert second.cached is True
+        assert second.content == first.content
+
+    def test_streaming_never_touches_cache(self):
+        client, provider = _make_client({"enabled": True})
+        assert client.cache is not None
+        messages = [{"role": "user", "content": "hello"}]
+
+        with pytest.raises(Exception):
+            client.completion.create(messages=messages, provider="fake", stream=True)
+
+        stats = client.cache.stats
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+        assert stats["size"] == 0
+        assert provider.call_count == 0
+
+    def test_tools_never_touch_cache(self):
+        from justllms.tools import tool
+
+        @tool
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        client, provider = _make_client({"enabled": True})
+        assert client.cache is not None
+        messages = [{"role": "user", "content": "add 1 and 2"}]
+
+        # FakeProvider has no tool adapter, so the tools path raises -- but
+        # crucially the cache is never consulted or written.
+        with pytest.raises(Exception):
+            client.completion.create(messages=messages, provider="fake", tools=[add])
+
+        stats = client.cache.stats
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+        assert stats["size"] == 0


### PR DESCRIPTION
## Summary

Adds exact-match response caching — identical requests are served from cache instead of re-hitting provider APIs, cutting cost and latency for repeated prompts (evals, retries, dev loops, FAQ-style traffic). Zero new dependencies: in-memory LRU plus a stdlib-`sqlite3` disk backend.

### What's new

- **`justllms/cache/`** package:
  - `InMemoryCache` — LRU (default 1000 entries) with per-entry TTL, thread-safe, hit/miss stats.
  - `DiskCache` — sqlite file DB (default `~/.justllms/cache.db`), persists across processes, lazy expiry purging.
  - `ResponseCache` — deterministic SHA-256 keying over provider + model + messages + generation params. Transport/cache-control keys (`timeout`, `stream`, `cache`, …) never affect the key, so they can't fragment the cache.
- **Config**:
  ```yaml
  cache:
    enabled: true
    backend: memory   # or "disk"
    ttl: 3600         # seconds; null = no expiry
    max_size: 1000    # memory backend
    path: null        # disk backend db path
  ```
- **Per-request control**: `cache=False` bypasses (no read/write), `cache_ttl=120` overrides TTL for one call. Passing `cache=True` when caching isn't configured raises a clear `ConfigurationError` rather than silently no-opping.
- **`cached: bool` flag on `CompletionResponse`** so callers can tell hits from fresh calls. Cached responses round-trip fully — `.content`, `.usage.estimated_cost`, `.provider` all preserved (cost is stored post-estimation).

### Scope
Only successful, non-streaming, non-tool completions are cached (streaming and tool-execution requests never touch the cache). Caching is off by default.

Also fixes a repo papercut: `.gitignore`'s blanket `test_*.py` rule (meant for scratch files) was silently ignoring real test files — added `!tests/test_*.py`.

## Testing
- 31 new tests in `tests/test_cache.py`: key determinism/sensitivity, memory TTL/LRU/thread-safety, disk roundtrip/TTL/cross-instance persistence, client hit/bypass/miss/ttl-override/misconfiguration, and streaming+tools isolation
- `ruff`, `black --check`, `mypy` (strict) all clean

https://claude.ai/code/session_01DC8Ax6EFiFnCFsGEHhW3MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC8Ax6EFiFnCFsGEHhW3MH)_