### PR TITLE
ci: run pytest suite in CI across Python 3.10-3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,31 @@ jobs:
       - name: Run mypy
         run: mypy justllms/ --ignore-missing-imports
 
+  test:
+    name: Tests - Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/ -v
+
   test-build:
     name: Test Build - Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a `test` job to CI that runs the pytest suite (94 tests: fallback, monitoring/budget, caching, token counter) on Python 3.10–3.13 — same matrix as the existing build job. Until now CI only linted, type-checked, and built the package; the test suites added by #44/#45/#46 weren't executed anywhere.

The job installs the package plus pytest and runs `pytest tests/ -v`. The token-encoding test self-skips in environments where tiktoken can't download encoding files, so it runs fully on GitHub runners.

## Testing
- Workflow YAML validated; `pytest tests/ -v` passes locally (93 passed, 1 env-conditional skip)
- The new job runs on this very PR — check the "Tests - Python 3.x" checks below

https://claude.ai/code/session_01DC8Ax6EFiFnCFsGEHhW3MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC8Ax6EFiFnCFsGEHhW3MH)_